### PR TITLE
ESCKAN-30 feat: Initialize graph diagram with mocked data from composer

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@metacell/geppetto-meta-ui": "^2.0.0-rc3",
     "@mui/icons-material": "^5.15.9",
     "@mui/material": "^5.15.9",
+    "@projectstorm/react-canvas-core": "^7.0.2",
+    "@projectstorm/react-diagrams": "^7.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-heatmap-grid": "^0.9.0",

--- a/src/components/connections/PopulationDisplay.tsx
+++ b/src/components/connections/PopulationDisplay.tsx
@@ -7,6 +7,8 @@ import {
 } from "@mui/material";
 import { vars } from "../../theme/variables.ts";
 import ConnectionsTableView from "./ConnectionsTableView.tsx";
+import GraphDiagram from "../graphDiagram/GraphDiagram.tsx";
+import {MOCKED_composerStatement} from "../../resources/mockedData/MOCKED_composerStatement.ts";
 
 const { gray700} = vars
 
@@ -62,7 +64,10 @@ const PopulationDisplay = () => {
         </Tabs>
       </Stack>
       <CustomTabPanel value={value} index={0}>
-        Graph view
+        <Box sx={{height: '800px', width: '100%'}}>
+          <GraphDiagram origins={MOCKED_composerStatement.origins} vias={MOCKED_composerStatement.vias}
+                        destinations={MOCKED_composerStatement.destinations}/>
+        </Box>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
         <ConnectionsTableView />

--- a/src/components/graphDiagram/GraphDiagram.tsx
+++ b/src/components/graphDiagram/GraphDiagram.tsx
@@ -1,0 +1,240 @@
+import React, {useEffect, useRef, useState} from "react";
+import InfoMenu from "./InfoMenu";
+import NavigationMenu from "./NavigationMenu";
+import createEngine, {
+    BasePositionModelOptions,
+    DefaultLinkModel,
+    DiagramModel,
+} from '@projectstorm/react-diagrams';
+import {CanvasWidget} from '@projectstorm/react-canvas-core';
+import {CustomNodeModel} from "./models/CustomNodeModel";
+import {CustomNodeFactory} from "./factories/CustomNodeFactory";
+import {
+    AnatomicalEntity,
+    DestinationSerializerDetails,
+    NodeTypes,
+    TypeB60Enum,
+    TypeC11Enum,
+    ViaSerializerDetails
+} from "../../models/composer";
+
+
+export interface CustomNodeOptions extends BasePositionModelOptions {
+    to?: Array<{ name: string; type: string }>;
+    from?: Array<{ name: string; type: string }>;
+    anatomicalType?: string
+}
+
+const ViaTypeMapping: Record<TypeB60Enum, string> = {
+    [TypeB60Enum.Axon]: 'Axon',
+    [TypeB60Enum.Dendrite]: 'Dendrite'
+};
+
+const DestinationTypeMapping: Record<TypeC11Enum, string> = {
+    [TypeC11Enum.AxonT]: 'Axon terminal',
+    [TypeC11Enum.AfferentT]: 'Afferent terminal',
+    [TypeC11Enum.Unknown]: 'Not specified'
+};
+
+interface GraphDiagramProps {
+    origins: AnatomicalEntity[] | undefined;
+    vias: ViaSerializerDetails[] | undefined;
+    destinations: DestinationSerializerDetails[] | undefined;
+}
+
+function getExternalID(url: string) {
+    const parts = url.split('/');
+    return parts[parts.length - 1].replace('_', ':');
+}
+
+function getId(layerId: string, entity: AnatomicalEntity) {
+    return layerId + entity.id.toString();
+}
+
+function findNodeForEntity(entity: AnatomicalEntity, nodeMap: Map<string, CustomNodeModel>, maxLayerIndex: number) {
+    for (let layerIndex = 0; layerIndex <= maxLayerIndex; layerIndex++) {
+        const layerId = layerIndex === 0 ? NodeTypes.Origin : NodeTypes.Via + layerIndex
+        const id = getId(layerId, entity);
+        if (nodeMap.has(id)) {
+            return nodeMap.get(id);
+        }
+    }
+    return null;
+}
+
+const createLink = (sourceNode: CustomNodeModel, targetNode: CustomNodeModel, sourcePortName: string, targetPortName: string) => {
+    const sourcePort = sourceNode.getPort(sourcePortName);
+    const targetPort = targetNode.getPort(targetPortName);
+    if (sourcePort && targetPort) {
+        const link = new DefaultLinkModel();
+        link.setSourcePort(sourcePort);
+        link.setTargetPort(targetPort);
+        return link;
+    }
+    return null;
+};
+
+const processData = (
+    origins: AnatomicalEntity[] | undefined,
+    vias: ViaSerializerDetails[] | undefined,
+    destinations: DestinationSerializerDetails[] | undefined,
+): { nodes: CustomNodeModel[], links: DefaultLinkModel[] } => {
+    const nodes: CustomNodeModel[] = [];
+    const links: DefaultLinkModel[] = [];
+
+    const nodeMap = new Map<string, CustomNodeModel>();
+
+    const yStart = 100
+    const yIncrement = 200; // Vertical spacing
+    const xIncrement = 200; // Horizontal spacing
+    let xOrigin = 100
+
+    origins?.forEach(origin => {
+        const id = getId(NodeTypes.Origin, origin)
+        const originNode = new CustomNodeModel(
+            NodeTypes.Origin,
+            origin.name,
+            getExternalID(origin.ontology_uri),
+            {
+                to: [],
+            }
+        );
+        originNode.setPosition(xOrigin, yStart);
+        nodes.push(originNode);
+        nodeMap.set(id, originNode);
+        xOrigin += xIncrement;
+    });
+
+
+    vias?.forEach((via) => {
+        const layerIndex = via.order + 1
+        let xVia = 100
+        let yVia = layerIndex * yIncrement + yStart;
+        via.anatomical_entities.forEach(entity => {
+            const id = getId(NodeTypes.Via + layerIndex, entity)
+            const viaNode = new CustomNodeModel(
+                NodeTypes.Via,
+                entity.name,
+                getExternalID(entity.ontology_uri),
+                {
+                    from: [],
+                    to: [],
+                    anatomicalType: via?.type ? ViaTypeMapping[via.type] : ''
+                }
+            );
+            viaNode.setPosition(xVia, yVia);
+            nodes.push(viaNode);
+            nodeMap.set(id, viaNode);
+            xVia += xIncrement
+
+            via.from_entities.forEach(fromEntity => {
+                const sourceNode = findNodeForEntity(fromEntity, nodeMap, layerIndex - 1);
+                if (sourceNode) {
+                    const link = createLink(sourceNode, viaNode, 'out', 'in');
+                    if (link) {
+                        links.push(link);
+                        const sourceOptions = sourceNode.getOptions() as CustomNodeOptions;
+                        const viaOptions = viaNode.getOptions() as CustomNodeOptions;
+                        sourceOptions.to?.push({name: viaNode.name, type: NodeTypes.Via});
+                        viaOptions.from?.push({name: sourceNode.name, type: sourceNode.getCustomType()})
+                    }
+                }
+            });
+        });
+        yVia += yIncrement;
+    });
+
+
+    const yDestination = yIncrement * ((vias?.length || 1) + 1) + yStart
+    let xDestination = 100
+
+
+    // Process Destinations
+    destinations?.forEach(destination => {
+        destination.anatomical_entities.forEach(entity => {
+            const destinationNode = new CustomNodeModel(
+                NodeTypes.Destination,
+                entity.name,
+                getExternalID(entity.ontology_uri),
+                {
+                    from: [],
+                    anatomicalType: destination?.type ? DestinationTypeMapping[destination.type] : ''
+                }
+            );
+            destinationNode.setPosition(xDestination, yDestination);
+            nodes.push(destinationNode);
+            xDestination += xIncrement;
+            xDestination += xIncrement;
+            destination.from_entities.forEach(fromEntity => {
+                const sourceNode = findNodeForEntity(fromEntity, nodeMap, vias?.length || 0);
+                if (sourceNode) {
+                    const link = createLink(sourceNode, destinationNode, 'out', 'in');
+                    if (link) {
+                        links.push(link);
+                        const sourceOptions = sourceNode.getOptions() as CustomNodeOptions;
+                        const destinationOptions = destinationNode.getOptions() as CustomNodeOptions;
+                        sourceOptions.to?.push({name: destinationNode.name, type: NodeTypes.Destination});
+                        destinationOptions.from?.push({name: sourceNode.name, type: sourceNode.getCustomType()})
+                    }
+                }
+            });
+        });
+    });
+
+    return {nodes, links};
+};
+
+const GraphDiagram: React.FC<GraphDiagramProps> = ({origins, vias, destinations}) => {
+    const [engine] = useState(() => createEngine());
+    const [modelUpdated, setModelUpdated] = useState(false)
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    // This effect runs once to set up the engine
+    useEffect(() => {
+        engine.getNodeFactories().registerFactory(new CustomNodeFactory());
+    }, [engine]);
+
+
+    // This effect runs whenever origins, vias, or destinations change
+    useEffect(() => {
+        const {nodes, links} = processData(origins, vias, destinations);
+
+        const model = new DiagramModel();
+        model.addAll(...nodes, ...links);
+
+        engine.setModel(model);
+        // engine.getModel().setLocked(true)
+        setModelUpdated(true)
+    }, [origins, vias, destinations, engine]);
+
+    // This effect prevents the default scroll and touchmove behavior
+    useEffect(() => {
+        const currentContainer = containerRef.current;
+
+        if (modelUpdated && currentContainer) {
+            const disableScroll = (event: Event) => {
+                event.stopPropagation();
+            };
+
+            currentContainer.addEventListener('wheel', disableScroll, {passive: false});
+            currentContainer.addEventListener('touchmove', disableScroll, {passive: false});
+
+            return () => {
+                currentContainer?.removeEventListener('wheel', disableScroll);
+                currentContainer?.removeEventListener('touchmove', disableScroll);
+            };
+        }
+    }, [modelUpdated]);
+
+    return (
+        modelUpdated ? (
+                <div ref={containerRef} className={"graphContainer"}>
+                    <NavigationMenu engine={engine}/>
+                    <InfoMenu engine={engine}/>
+                    <CanvasWidget className={"graphContainer"} engine={engine}/>
+                </div>)
+            : null
+    );
+}
+
+export default GraphDiagram;

--- a/src/components/graphDiagram/InfoMenu.tsx
+++ b/src/components/graphDiagram/InfoMenu.tsx
@@ -1,0 +1,87 @@
+import {Stack, Typography} from "@mui/material";
+import {
+    DestinationInfoIcon,
+    OriginInfoIcon,
+    ViaInfoIcon,
+} from "../../icons";
+import {DiagramEngine} from "@projectstorm/react-diagrams-core";
+
+
+interface InfoMenuProps {
+    engine: DiagramEngine;
+}
+const InfoMenu = (props: InfoMenuProps) => {
+    const {engine} = props
+    return engine ? (
+        <Stack
+            direction="row"
+            spacing="1rem"
+            sx={{
+                borderRadius: "1.75rem",
+                border: "1px solid #F2F4F7",
+                background: "#FFFFFF7F",
+                backgroundFilter: "blur(4px)",
+                width: "fit-content",
+                boxShadow:
+                    "0px 4px 6px -2px rgba(16, 24, 40, 0.03), 0px 12px 16px -4px rgba(16, 24, 40, 0.08)",
+                padding: "0.75rem 1.25rem",
+                position: "absolute",
+                left: 8,
+                bottom: 8,
+                zIndex: 10,
+
+                "& .MuiSvgIcon-root": {
+                    color: "#475467",
+                },
+
+                "& .MuiDivider-root": {
+                    borderColor: "#EAECF0",
+                    borderWidth: 0.5,
+                },
+                "& .MuiButtonBase-root": {
+                    padding: 0,
+
+                    "&:hover": {
+                        backgroundColor: "transparent",
+                    },
+                },
+            }}
+        >
+            <Stack direction="row" alignItems="center">
+                <OriginInfoIcon/>
+                <Typography
+                    sx={{
+                        color: "#039855",
+                        fontWeight: 500,
+                    }}
+                >
+                    Origins
+                </Typography>
+            </Stack>
+            <Stack direction="row" alignItems="center">
+                <ViaInfoIcon/>
+                <Typography
+                    sx={{
+                        color: "#0E9384",
+                        fontWeight: 500,
+                    }}
+                >
+                    Via
+                </Typography>
+            </Stack>
+            <Stack direction="row" alignItems="center">
+                <DestinationInfoIcon/>
+                <Typography
+                    sx={{
+                        color: "#088AB2",
+                        fontWeight: 500,
+                    }}
+                >
+                    Destination
+                </Typography>
+            </Stack>
+        </Stack>
+    ) : null;
+};
+
+export default InfoMenu;

--- a/src/components/graphDiagram/NavigationMenu.tsx
+++ b/src/components/graphDiagram/NavigationMenu.tsx
@@ -1,0 +1,77 @@
+import {Stack, Divider} from "@mui/material";
+import FitScreenOutlinedIcon from "@mui/icons-material/FitScreenOutlined";
+import ZoomInOutlinedIcon from "@mui/icons-material/ZoomInOutlined";
+import ZoomOutOutlinedIcon from "@mui/icons-material/ZoomOutOutlined";
+import IconButton from "@mui/material/IconButton";
+import {DiagramEngine} from "@projectstorm/react-diagrams-core";
+
+const ZOOM_CHANGE = 25
+
+interface NavigationMenuProps {
+    engine: DiagramEngine;
+}
+
+const NavigationMenu = (props: NavigationMenuProps) => {
+    const {engine} = props
+
+    const zoomOut = () => {
+        const zoomLevel = engine.getModel().getZoomLevel();
+        engine.getModel().setZoomLevel(zoomLevel - ZOOM_CHANGE);
+        engine.repaintCanvas();
+    };
+
+    const zoomIn = () => {
+        const zoomLevel = engine.getModel().getZoomLevel();
+        engine.getModel().setZoomLevel(zoomLevel + ZOOM_CHANGE);
+        engine.repaintCanvas();
+
+    };
+    return engine ? (
+        <Stack
+            direction="row"
+            spacing="1rem"
+            sx={{
+                borderRadius: "1.75rem",
+                border: "1px solid #F2F4F7",
+                background: "#FFF",
+                width: "fit-content",
+                boxShadow:
+                    "0px 4px 6px -2px rgba(16, 24, 40, 0.03), 0px 12px 16px -4px rgba(16, 24, 40, 0.08)",
+                padding: "0.75rem 1.25rem",
+                position: "absolute",
+                top: 8,
+                right: 8,
+                zIndex: 10,
+
+                "& .MuiSvgIcon-root": {
+                    color: "#475467",
+                },
+
+                "& .MuiDivider-root": {
+                    borderColor: "#EAECF0",
+                    borderWidth: 0.5,
+                },
+                "& .MuiButtonBase-root": {
+                    padding: 0,
+
+                    "&:hover": {
+                        backgroundColor: "transparent",
+                    },
+                },
+            }}
+        >
+            <IconButton onClick={() => engine.zoomToFit()}>
+                <FitScreenOutlinedIcon/>
+            </IconButton>
+            <Divider/>
+            <IconButton onClick={() => zoomIn()}>
+                <ZoomInOutlinedIcon/>
+            </IconButton>
+            <IconButton>
+                <ZoomOutOutlinedIcon onClick={() => zoomOut()}/>
+            </IconButton>
+        </Stack>
+    ) : null;
+};
+
+export default NavigationMenu;

--- a/src/components/graphDiagram/factories/CustomNodeFactory.tsx
+++ b/src/components/graphDiagram/factories/CustomNodeFactory.tsx
@@ -1,0 +1,33 @@
+import {AbstractReactFactory, GenerateWidgetEvent} from '@projectstorm/react-canvas-core';
+import {CustomNodeModel} from "../models/CustomNodeModel";
+import {Fragment} from "react";
+import {OriginNodeWidget} from "../widgets/OriginNodeWidget";
+import {ViaNodeWidget} from "../widgets/ViaNodeWidget";
+import {DestinationNodeWidget} from "../widgets/DestinationNodeWidget";
+import {DiagramEngine, NodeModel, NodeModelGenerics} from "@projectstorm/react-diagrams";
+import { NodeTypes } from '../../../models/composer';
+
+export class CustomNodeFactory extends AbstractReactFactory<NodeModel<NodeModelGenerics>, DiagramEngine>  {
+    constructor() {
+        super('custom');
+    }
+
+    generateModel() {
+        return new CustomNodeModel(NodeTypes.Origin, '');
+    }
+
+    generateReactWidget(event: GenerateWidgetEvent<CustomNodeModel>) {
+        const { customType } = event.model;
+
+        switch (customType) {
+            case NodeTypes.Origin:
+                return <OriginNodeWidget engine={this.engine} model={event.model} />;
+            case NodeTypes.Via:
+                return <ViaNodeWidget engine={this.engine} model={event.model} />;
+            case NodeTypes.Destination:
+                return <DestinationNodeWidget engine={this.engine} model={event.model} />;
+            default:
+                return <Fragment></Fragment>;
+        }
+    }
+}

--- a/src/components/graphDiagram/models/CustomNodeModel.tsx
+++ b/src/components/graphDiagram/models/CustomNodeModel.tsx
@@ -1,0 +1,33 @@
+import { NodeModel, DefaultPortModel } from '@projectstorm/react-diagrams';
+import { NodeTypes } from '../../../models/composer';
+import {CustomNodeOptions} from "../GraphDiagram.tsx";
+
+export class CustomNodeModel extends NodeModel {
+    customType: NodeTypes;
+    name: string;
+    externalId: string;
+    constructor(customType: NodeTypes, name: string, externalId: string = '',  options: CustomNodeOptions = {}) {
+        super({
+            ...options,
+            type: 'custom',
+        });
+        this.customType = customType;
+        this.name = name;
+        this.externalId = externalId;
+
+        if (customType === NodeTypes.Origin || customType === NodeTypes.Via) {
+            this.addPort(new DefaultPortModel(false, 'out', 'Out'));
+        }
+        if (customType === NodeTypes.Via || customType === NodeTypes.Destination) {
+            this.addPort(new DefaultPortModel(true, 'in', 'In'));
+        }
+    }
+
+    getCustomType() {
+        return this.customType;
+    }
+
+    getOptions(): CustomNodeOptions {
+        return super.getOptions() as CustomNodeOptions;
+    }
+}

--- a/src/components/graphDiagram/widgets/DestinationNodeWidget.tsx
+++ b/src/components/graphDiagram/widgets/DestinationNodeWidget.tsx
@@ -1,0 +1,202 @@
+import React, {useState} from "react";
+import {PortWidget} from "@projectstorm/react-diagrams";
+import {Typography, Box} from "@mui/material";
+import Stack from "@mui/material/Stack";
+import Divider from "@mui/material/Divider";
+import Chip from "@mui/material/Chip";
+import {CustomNodeModel} from "../models/CustomNodeModel.tsx";
+import {DiagramEngine} from "@projectstorm/react-diagrams-core";
+import {NodeTypes} from "../../../models/composer.ts";
+import {DestinationIcon, OriginIcon, ViaIcon} from "../../../icons";
+import {vars} from "../../../theme/variables.ts";
+
+interface DestinationNodeProps {
+    model: CustomNodeModel;
+    engine: DiagramEngine;
+}
+
+export const DestinationNodeWidget: React.FC<DestinationNodeProps> = ({
+                                                                          model,
+                                                                          engine,
+                                                                      }) => {
+    // State to toggle the color
+    const [isActive, setIsActive] = useState(false);
+    const [zIndex, setZIndex] = useState(0);
+
+    // Function to toggle the state
+    const toggleColor = () => {
+        setIsActive(!isActive);
+        setZIndex((prevZIndex) => prevZIndex + 1);
+    };
+
+
+    const inPort = model.getPort("in");
+
+    return (
+        <Box
+            style={{
+                display: "flex",
+                width: "10rem",
+                height: "10rem",
+                padding: "0.5rem",
+                flexDirection: "column",
+                justifyContent: "center",
+                alignItems: "center",
+                gap: "0.25rem",
+                borderRadius: "0.75rem",
+                border: "2px solid #088AB2",
+                background: "#ECFDFF",
+                boxShadow:
+                    "0px 4px 10px -4px rgba(8, 138, 178, 0.20), 0px 0px 26px 0px #A5F0FC inset",
+            }}
+            onClick={toggleColor}
+        >
+            <Typography
+                sx={{
+                    color: "#088AB2",
+                    textAlign: "center",
+                    fontSize: "0.875rem",
+                    fontWeight: 500,
+                    lineHeight: "1.25rem",
+                }}
+            >
+                {model.name}
+            </Typography>
+            {inPort && <PortWidget engine={engine} port={inPort}>
+              <div className="circle-port"/>
+            </PortWidget>}
+
+            {isActive && (
+                <Box
+                    style={{
+                        display: "flex",
+                        padding: "0.5rem",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        gap: "0.25rem",
+                        borderRadius: "0.75rem",
+                        border: "2px solid #088AB2",
+                        background: "#ECFDFF",
+                        boxShadow: "0px 4px 10px -4px rgba(8, 138, 178, 0.20)",
+                        position: "absolute",
+                        top: 0,
+                        width: "18rem",
+                        zIndex: isActive ? zIndex : "auto",
+                    }}
+                >
+                    <Box
+                        sx={{
+                            padding: "0.75rem 0.5rem",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            textAlign: "center",
+                        }}
+                    >
+                        <Typography
+                            sx={{
+                                color: " #088AB2",
+                                fontSize: "0.875rem",
+                                fontWeight: 500,
+                            }}
+                        >
+                            From
+                        </Typography>
+                    </Box>
+                    <Box
+                        sx={{
+                            borderRadius: "0.625rem",
+                            border: "1px solid #EAECF0",
+                            background: "#FFF",
+                            width: "100%",
+                        }}
+                    >
+                        {model.getOptions().from?.map((item: {
+                            type: string;
+                            name: string
+                        }, index: number) => (
+                            <React.Fragment key={index}>
+                                <Stack
+                                    padding=".5rem"
+                                    spacing={1}
+                                    direction="row"
+                                    alignItems="center"
+                                >
+                                    {item.type === NodeTypes.Origin &&
+                                      <OriginIcon fill="#088AB2" width={"1rem"} height={"1rem"}/>}
+                                    {item.type === NodeTypes.Via &&
+                                      <ViaIcon fill="#088AB2" width={"1rem"} height={"1rem"}/>}
+                                    <Typography
+                                        sx={{
+                                            color: "#667085",
+                                            fontSize: "0.875rem",
+                                            fontWeight: 500,
+                                            lineHeight: "1.25rem",
+                                        }}
+                                    >
+                                        {item.name}
+                                    </Typography>
+                                </Stack>
+                                {index < (model.getOptions().from?.length ?? 0) - 1 && <Divider/>}
+                            </React.Fragment>
+                        ))}
+                    </Box>
+
+
+                    <Stack
+                        padding="0.75rem 0.5rem"
+                        alignItems="center"
+                        justifyContent="center"
+                        textAlign="center"
+                        spacing={2}
+                    >
+                        <Box
+                            style={{
+                                width: "1rem",
+                                height: "0.125rem",
+                                backgroundColor: " #06AED4",
+                                transform: "rotate(90deg)",
+                            }}
+                        />
+                        <DestinationIcon fill="#088AB2"/>
+                        <Typography
+                            sx={{
+                                color: " #088AB2",
+                                fontSize: "0.875rem",
+                                fontWeight: 500,
+                                lineHeight: "1.25rem",
+                            }}
+                        >
+                            {model.name}
+                        </Typography>
+                        <Typography
+                            sx={{
+                                color: " #088AB2",
+                                fontSize: "0.75rem",
+                                fontWeight: 400,
+                                lineHeight: "1.125rem",
+                                marginTop: ".25rem !important",
+                            }}
+                        >
+                            {model.externalId}
+                        </Typography>
+                        <Chip
+                            label={model.getOptions().anatomicalType}
+                            variant="filled"
+                            sx={{
+                                background: "#E2ECFB",
+                                color: "#184EA2",
+                                marginLeft: "10px",
+                                marginRight: "10px",
+
+                                "& .MuiChip-deleteIcon": {
+                                    fontSize: "14px",
+                                    color: vars.mediumBlue,
+                                },
+                            }}
+                        />
+                    </Stack>
+                </Box>
+            )}
+        </Box>
+    );
+};

--- a/src/components/graphDiagram/widgets/OriginNodeWidget.tsx
+++ b/src/components/graphDiagram/widgets/OriginNodeWidget.tsx
@@ -1,0 +1,164 @@
+import React, {useState} from "react";
+import {PortWidget} from "@projectstorm/react-diagrams";
+import {Typography, Box} from "@mui/material";
+import {DestinationIcon, OriginIcon, ViaIcon} from "../../../icons";
+import Stack from "@mui/material/Stack";
+import Divider from "@mui/material/Divider";
+import {CustomNodeModel} from "../models/CustomNodeModel.tsx";
+import {DiagramEngine} from "@projectstorm/react-diagrams-core";
+import {NodeTypes} from "../../../models/composer.ts";
+
+interface OriginNodeProps {
+    model: CustomNodeModel;
+    engine: DiagramEngine;
+}
+
+export const OriginNodeWidget: React.FC<OriginNodeProps> = ({
+                                                                model,
+                                                                engine,
+                                                            }) => {
+    const [isActive, setIsActive] = useState(false);
+    const [zIndex, setZIndex] = useState(0);
+
+    const toggleColor = () => {
+        setIsActive(!isActive);
+        setZIndex((prevZIndex) => prevZIndex + 1);
+    };
+
+    const outPort = model.getPort("out");
+
+    return (
+        <Box
+            style={{
+                position: "relative",
+                display: "flex",
+                width: "10rem",
+                height: "10rem",
+                padding: "0.5rem",
+                flexDirection: "column",
+                justifyContent: "center",
+                alignItems: "center",
+                gap: "0.25rem",
+                borderRadius: "50rem",
+                border: "2px solid #039855",
+                background: "#ECFDF3",
+                boxShadow:
+                    "0px 4px 10px -4px rgba(3, 152, 85, 0.20), 0px 0px 26px 0px #A6F4C5 inset",
+            }}
+            onClick={toggleColor}
+        >
+            <Typography
+                sx={{
+                    color: "#0E9384",
+                    textAlign: "center",
+                    fontSize: "0.875rem",
+                    fontWeight: 500,
+                    lineHeight: "1.25rem",
+                }}
+            >
+                {model.name}
+            </Typography>
+            {outPort && <PortWidget engine={engine} port={outPort}>
+              <div className="circle-port"/>
+            </PortWidget>
+            }
+
+            {isActive && (
+                <Box
+                    style={{
+                        display: "flex",
+                        padding: "0.5rem",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        gap: "0.25rem",
+                        borderRadius: "0.75rem",
+                        border: "2px solid #039855",
+                        background: "#ECFDF3",
+                        boxShadow: "0px 4px 10px -4px rgba(3, 152, 85, 0.20)",
+                        position: "absolute",
+                        top: 0,
+                        width: "18rem",
+                        zIndex: isActive ? zIndex : "auto",
+                    }}
+                >
+                    <Stack
+                        padding="0.75rem 0.5rem"
+                        alignItems="center"
+                        justifyContent="center"
+                        textAlign="center"
+                        spacing={2}
+                    >
+                        <OriginIcon fill="#039855"/>
+                        <Typography
+                            sx={{
+                                color: " #039855",
+                                fontSize: "0.875rem",
+                                fontWeight: 500,
+                                lineHeight: "1.25rem",
+                            }}
+                        >
+                            Intermediolateral nucleus of eleventh thoracic segment
+                        </Typography>
+                        <Typography
+                            sx={{
+                                color: " #039855",
+                                fontSize: "0.75rem",
+                                fontWeight: 400,
+                                lineHeight: "1.125rem",
+                                marginTop: ".25rem !important",
+                            }}
+                        >
+                            {model.externalId}
+                        </Typography>
+                        <Box
+                            style={{
+                                width: "1rem",
+                                height: "0.125rem",
+                                backgroundColor: " #12B76A",
+                                transform: "rotate(90deg)",
+                            }}
+                        />
+                        <Typography
+                            sx={{
+                                color: " #039855",
+                                fontSize: "0.875rem",
+                                fontWeight: 500,
+                                lineHeight: "1.25rem",
+                            }}
+                        >
+                            To
+                        </Typography>
+                    </Stack>
+                    <Box
+                        sx={{
+                            borderRadius: "0.625rem",
+                            border: "1px solid #EAECF0",
+                            background: "#FFF",
+                            width: "100%",
+                        }}
+                    >
+                        {model.getOptions().to?.map((item: { type: string; name: string }, index: number) => (
+                            <React.Fragment key={index}>
+                                {index > 0 && <Divider/>}
+                                <Stack padding=".5rem" spacing={1} direction="row" alignItems="center">
+                                    {item.type === NodeTypes.Via &&
+                                      <ViaIcon fill="#039855" width={"1rem"} height={"1rem"}/>}
+                                    {item.type === NodeTypes.Destination &&
+                                      <DestinationIcon fill="#0E9384" width={"1rem"} height={"1rem"}/>}
+                                    <Typography sx={{
+                                        color: "#667085",
+                                        fontSize: "0.875rem",
+                                        fontWeight: 500,
+                                        lineHeight: "1.25rem"
+                                    }}>
+                                        {item.name}
+                                    </Typography>
+                                </Stack>
+                            </React.Fragment>
+                        ))}
+                    </Box>
+                </Box>
+            )}
+        </Box>
+    );
+};

--- a/src/components/graphDiagram/widgets/ViaNodeWidget.tsx
+++ b/src/components/graphDiagram/widgets/ViaNodeWidget.tsx
@@ -1,0 +1,247 @@
+import React, {useState} from "react";
+import {PortWidget} from "@projectstorm/react-diagrams";
+import {Typography, Box} from "@mui/material";
+import Stack from "@mui/material/Stack";
+import {DestinationIcon, OriginIcon, ViaIcon} from "../../../icons";
+import Divider from "@mui/material/Divider";
+import Chip from "@mui/material/Chip";
+import {CustomNodeModel} from "../models/CustomNodeModel.tsx";
+import {DiagramEngine} from "@projectstorm/react-diagrams-core";
+import {NodeTypes} from "../../../models/composer.ts";
+import {vars} from "../../../theme/variables.ts";
+
+interface ViaNodeProps {
+    model: CustomNodeModel;
+    engine: DiagramEngine;
+}
+
+export const ViaNodeWidget: React.FC<ViaNodeProps> = ({model, engine}) => {
+    // State to toggle the color
+    const [isActive, setIsActive] = useState(false);
+    const [zIndex, setZIndex] = useState(0);
+    // Function to toggle the state
+    const toggleColor = () => {
+        setIsActive(!isActive);
+        setZIndex((prevZIndex) => prevZIndex + 1);
+    };
+
+    const outPort = model.getPort("out");
+    const inPort = model.getPort("in");
+
+
+    return (
+        <Box
+            style={{
+                display: "flex",
+                width: "10rem",
+                height: "10rem",
+                padding: "0.5rem",
+                flexDirection: "column",
+                justifyContent: "center",
+                alignItems: "center",
+                gap: "0.25rem",
+                borderRadius: "3.25rem",
+                border: "2px solid #0E9384",
+                background: "#F0FDF9",
+                boxShadow:
+                    "0px 4px 10px -4px rgba(14, 147, 132, 0.20), 0px 0px 26px 0px #99F6E0 inset",
+            }}
+            onClick={toggleColor}
+        >
+            <Typography
+                sx={{
+                    color: "#0E9384",
+                    textAlign: "center",
+                    fontSize: "0.875rem",
+                    fontWeight: 500,
+                    lineHeight: "1.25rem",
+                }}
+            >
+                {model.name}
+            </Typography>
+            {inPort && <PortWidget engine={engine} port={inPort}>
+              <div className="circle-port"/>
+            </PortWidget>}
+            {outPort && <PortWidget engine={engine} port={outPort}>
+              <div className="circle-port"/>
+            </PortWidget>}
+
+            {isActive && (
+                <Box
+                    style={{
+                        display: "flex",
+                        padding: "0.5rem",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        gap: "0.25rem",
+                        borderRadius: "0.75rem",
+                        border: "2px solid #039855",
+                        background: "#ECFDF3",
+                        boxShadow: "0px 4px 10px -4px rgba(3, 152, 85, 0.20)",
+                        position: "absolute",
+                        top: 0,
+                        width: "18rem",
+                        zIndex: isActive ? zIndex : "auto",
+                        maxHeight: "36rem",
+                    }}
+                >
+                    <Box
+                        sx={{
+                            padding: "0.75rem 0.5rem",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            textAlign: "center",
+                        }}
+                    >
+                        <Typography
+                            sx={{
+                                color: " #039855",
+                                fontSize: "0.875rem",
+                                fontWeight: 500,
+                            }}
+                        >
+                            From
+                        </Typography>
+                    </Box>
+                    <Box
+                        sx={{
+                            borderRadius: "0.625rem",
+                            border: "1px solid #EAECF0",
+                            background: "#FFF",
+                            width: "100%",
+                        }}
+                    >
+                        {model.getOptions().from?.map((item: {
+                            type: string;
+                            name: string
+                        }, index: number) => (
+                            <React.Fragment key={index}>
+                                <Stack
+                                    padding=".5rem"
+                                    spacing={1}
+                                    direction="row"
+                                    alignItems="center"
+                                >
+                                    {item.type === NodeTypes.Origin &&
+                                      <OriginIcon fill="#088AB2" width={"1rem"} height={"1rem"}/>}
+                                    {item.type === NodeTypes.Via &&
+                                      <ViaIcon fill="#088AB2" width={"1rem"} height={"1rem"}/>}
+                                    <Typography
+                                        sx={{
+                                            color: "#667085",
+                                            fontSize: "0.875rem",
+                                            fontWeight: 500,
+                                            lineHeight: "1.25rem",
+                                        }}
+                                    >
+                                        {item.name}
+                                    </Typography>
+                                </Stack>
+                                {index < (model.getOptions().from?.length ?? 0) - 1 && <Divider/>}
+                            </React.Fragment>
+                        ))}
+                    </Box>
+
+                    <Stack
+                        padding="0.75rem 0.5rem"
+                        alignItems="center"
+                        justifyContent="center"
+                        textAlign="center"
+                        spacing={2}
+                    >
+                        <Box
+                            style={{
+                                width: "1rem",
+                                height: "0.125rem",
+                                backgroundColor: " #0E9384",
+                                transform: "rotate(90deg)",
+                            }}
+                        />
+                        <ViaIcon fill="#0E9384"/>
+                        <Typography
+                            sx={{
+                                color: " #0E9384",
+                                fontSize: "0.875rem",
+                                fontWeight: 500,
+                                lineHeight: "1.25rem",
+                            }}
+                        >
+                            {model.name}
+                        </Typography>
+                        <Typography
+                            sx={{
+                                color: " #0E9384",
+                                fontSize: "0.75rem",
+                                fontWeight: 400,
+                                lineHeight: "1.125rem",
+                                marginTop: ".25rem !important",
+                            }}
+                        >
+                            {model.externalId}
+                        </Typography>
+                        <Chip
+                            label={model.getOptions().anatomicalType}
+                            variant="filled"
+                            sx={{
+                                background: vars.lightBlue,
+                                color: vars.darkBlue,
+                                marginLeft: "10px",
+                                marginRight: "10px",
+
+                                "& .MuiChip-deleteIcon": {
+                                    fontSize: "14px",
+                                    color: vars.mediumBlue,
+                                },
+                            }}
+                        />
+                        <Box
+                            style={{
+                                width: "1rem",
+                                height: "0.125rem",
+                                backgroundColor: " #0E9384",
+                                transform: "rotate(90deg)",
+                            }}
+                        />
+                        <Typography
+                            sx={{
+                                color: " #039855",
+                                fontSize: "0.875rem",
+                                fontWeight: 500,
+                            }}
+                        >
+                            To
+                        </Typography>
+                    </Stack>
+                    <Box
+                        sx={{
+                            borderRadius: "0.625rem",
+                            border: "1px solid #EAECF0",
+                            background: "#FFF",
+                            width: "100%",
+                        }}
+                    >
+                        {model.getOptions().to?.map((item: { type: string; name: string }, index: number) => (
+                            <React.Fragment key={index}>
+                                {index > 0 && <Divider/>}
+                                <Stack padding=".5rem" spacing={1} direction="row" alignItems="center">
+                                    {item.type === NodeTypes.Via &&
+                                      <ViaIcon fill="#039855" width={"1rem"} height={"1rem"}/>}
+                                    {item.type === NodeTypes.Destination &&
+                                      <DestinationIcon fill="#0E9384" width={"1rem"} height={"1rem"}/>}
+                                    <Typography sx={{
+                                        color: "#667085",
+                                        fontSize: "0.875rem",
+                                        fontWeight: 500,
+                                        lineHeight: "1.25rem"
+                                    }}>
+                                        {item.name}
+                                    </Typography>
+                                </Stack>
+                            </React.Fragment>
+                        ))}
+                    </Box>
+                </Box>
+            )}
+        </Box>
+    );
+};

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -1,4 +1,5 @@
 import { SvgIcon } from "@mui/material";
+import {SvgIconProps} from "@mui/material/SvgIcon";
 
 export const ArrowUp = () => (
   <SvgIcon viewBox="0 0 20 20">
@@ -43,4 +44,362 @@ export const HelpCircle = () => (
       </defs>
     </svg>
   </SvgIcon>
+);
+
+export const OriginInfoIcon = (props: SvgIconProps) => (
+    <SvgIcon
+        {...props}
+        viewBox="0 0 36 26"
+        sx={{
+            width: props.width ? props.width : 36,
+            height: props.height ? props.height : 36,
+        }}
+    >
+        <g filter="url(#filter0_di_3328_77745)">
+            <rect x="6" y="2" width="24" height="24" rx="12" fill="#ECFDF3" />
+            <rect
+                x="7"
+                y="3"
+                width="22"
+                height="22"
+                rx="11"
+                stroke="#039855"
+                stroke-width="2"
+            />
+        </g>
+        <defs>
+            <filter
+                id="filter0_di_3328_77745"
+                x="0"
+                y="0"
+                width="36"
+                height="36"
+                filterUnits="userSpaceOnUse"
+                color-interpolation-filters="sRGB"
+            >
+                <feFlood flood-opacity="0" result="BackgroundImageFix" />
+                <feColorMatrix
+                    in="SourceAlpha"
+                    type="matrix"
+                    values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+                    result="hardAlpha"
+                />
+                <feMorphology
+                    radius="4"
+                    operator="erode"
+                    in="SourceAlpha"
+                    result="effect1_dropShadow_3328_77745"
+                />
+                <feOffset dy="4" />
+                <feGaussianBlur stdDeviation="5" />
+                <feComposite in2="hardAlpha" operator="out" />
+                <feColorMatrix
+                    type="matrix"
+                    values="0 0 0 0 0.0121568 0 0 0 0 0.595686 0 0 0 0 0.333098 0 0 0 0.2 0"
+                />
+                <feBlend
+                    mode="normal"
+                    in2="BackgroundImageFix"
+                    result="effect1_dropShadow_3328_77745"
+                />
+                <feBlend
+                    mode="normal"
+                    in="SourceGraphic"
+                    in2="effect1_dropShadow_3328_77745"
+                    result="shape"
+                />
+                <feColorMatrix
+                    in="SourceAlpha"
+                    type="matrix"
+                    values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+                    result="hardAlpha"
+                />
+                <feOffset />
+                <feGaussianBlur stdDeviation="13" />
+                <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+                <feColorMatrix
+                    type="matrix"
+                    values="0 0 0 0 0.65098 0 0 0 0 0.956863 0 0 0 0 0.772549 0 0 0 1 0"
+                />
+                <feBlend
+                    mode="normal"
+                    in2="shape"
+                    result="effect2_innerShadow_3328_77745"
+                />
+            </filter>
+        </defs>
+    </SvgIcon>
+);
+export const ViaInfoIcon = (props: SvgIconProps) => (
+    <SvgIcon
+        {...props}
+        viewBox="0 0 36 26"
+        sx={{
+            width: props.width ? props.width : 36,
+            height: props.height ? props.height : 36,
+        }}
+    >
+        <g filter="url(#filter0_di_3328_77749)">
+            <rect x="6" y="2" width="24" height="24" rx="8" fill="#F0FDF9" />
+            <rect
+                x="7"
+                y="3"
+                width="22"
+                height="22"
+                rx="7"
+                stroke="#0E9384"
+                stroke-width="2"
+            />
+        </g>
+        <defs>
+            <filter
+                id="filter0_di_3328_77749"
+                x="0"
+                y="0"
+                width="36"
+                height="36"
+                filterUnits="userSpaceOnUse"
+                color-interpolation-filters="sRGB"
+            >
+                <feFlood flood-opacity="0" result="BackgroundImageFix" />
+                <feColorMatrix
+                    in="SourceAlpha"
+                    type="matrix"
+                    values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+                    result="hardAlpha"
+                />
+                <feMorphology
+                    radius="4"
+                    operator="erode"
+                    in="SourceAlpha"
+                    result="effect1_dropShadow_3328_77749"
+                />
+                <feOffset dy="4" />
+                <feGaussianBlur stdDeviation="5" />
+                <feComposite in2="hardAlpha" operator="out" />
+                <feColorMatrix
+                    type="matrix"
+                    values="0 0 0 0 0.054902 0 0 0 0 0.576471 0 0 0 0 0.517647 0 0 0 0.2 0"
+                />
+                <feBlend
+                    mode="normal"
+                    in2="BackgroundImageFix"
+                    result="effect1_dropShadow_3328_77749"
+                />
+                <feBlend
+                    mode="normal"
+                    in="SourceGraphic"
+                    in2="effect1_dropShadow_3328_77749"
+                    result="shape"
+                />
+                <feColorMatrix
+                    in="SourceAlpha"
+                    type="matrix"
+                    values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+                    result="hardAlpha"
+                />
+                <feOffset />
+                <feGaussianBlur stdDeviation="13" />
+                <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+                <feColorMatrix
+                    type="matrix"
+                    values="0 0 0 0 0.6 0 0 0 0 0.964706 0 0 0 0 0.878431 0 0 0 1 0"
+                />
+                <feBlend
+                    mode="normal"
+                    in2="shape"
+                    result="effect2_innerShadow_3328_77749"
+                />
+            </filter>
+        </defs>
+    </SvgIcon>
+);
+export const DestinationInfoIcon = (props: SvgIconProps) => (
+    <SvgIcon
+        {...props}
+        viewBox="0 0 36 26"
+        sx={{
+            width: props.width ? props.width : 36,
+            height: props.height ? props.height : 36,
+        }}
+    >
+        <g filter="url(#filter0_di_3328_77753)">
+            <rect x="6" y="2" width="24" height="24" rx="4" fill="#ECFDFF" />
+            <rect
+                x="7"
+                y="3"
+                width="22"
+                height="22"
+                rx="3"
+                stroke="#088AB2"
+                stroke-width="2"
+            />
+        </g>
+        <defs>
+            <filter
+                id="filter0_di_3328_77753"
+                x="0"
+                y="0"
+                width="36"
+                height="36"
+                filterUnits="userSpaceOnUse"
+                color-interpolation-filters="sRGB"
+            >
+                <feFlood flood-opacity="0" result="BackgroundImageFix" />
+                <feColorMatrix
+                    in="SourceAlpha"
+                    type="matrix"
+                    values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+                    result="hardAlpha"
+                />
+                <feMorphology
+                    radius="4"
+                    operator="erode"
+                    in="SourceAlpha"
+                    result="effect1_dropShadow_3328_77753"
+                />
+                <feOffset dy="4" />
+                <feGaussianBlur stdDeviation="5" />
+                <feComposite in2="hardAlpha" operator="out" />
+                <feColorMatrix
+                    type="matrix"
+                    values="0 0 0 0 0.0313726 0 0 0 0 0.541176 0 0 0 0 0.698039 0 0 0 0.2 0"
+                />
+                <feBlend
+                    mode="normal"
+                    in2="BackgroundImageFix"
+                    result="effect1_dropShadow_3328_77753"
+                />
+                <feBlend
+                    mode="normal"
+                    in="SourceGraphic"
+                    in2="effect1_dropShadow_3328_77753"
+                    result="shape"
+                />
+                <feColorMatrix
+                    in="SourceAlpha"
+                    type="matrix"
+                    values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+                    result="hardAlpha"
+                />
+                <feOffset />
+                <feGaussianBlur stdDeviation="13" />
+                <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+                <feColorMatrix
+                    type="matrix"
+                    values="0 0 0 0 0.647059 0 0 0 0 0.941176 0 0 0 0 0.988235 0 0 0 1 0"
+                />
+                <feBlend
+                    mode="normal"
+                    in2="shape"
+                    result="effect2_innerShadow_3328_77753"
+                />
+            </filter>
+        </defs>
+    </SvgIcon>
+);
+
+export const ViaIcon = (props: SvgIconProps) => (
+    <SvgIcon
+        {...props}
+        viewBox="0 0 24 24"
+        sx={{
+            width: props.width ? props.width : 24,
+            height: props.height ? props.height : 24,
+        }}
+    >
+        <g clip-path="url(#clip0_2956_213155)">
+            <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M17.149 19.7649C17.4753 20.1473 18.0499 20.1927 18.4323 19.8664L21.6056 16.6193C21.988 16.293 22.0335 15.7184 21.7071 15.336C21.3808 14.9536 20.8062 14.9081 20.4238 15.2345L18.6426 17.2934C18.4845 17.085 18.2382 16.9459 17.9563 16.9337C17.7129 16.9232 17.4877 17.0093 17.3177 17.158L15.3358 15.2379C15.0095 14.8555 14.4349 14.81 14.0525 15.1364C13.6701 15.4627 13.6246 16.0373 13.951 16.4197L17.149 19.7649ZM17.9738 16.0863C18.4765 16.0847 18.8828 15.6759 18.8812 15.1731C18.8785 14.3243 18.8559 13.3981 18.7989 12.455C18.7686 11.9532 18.3372 11.5709 17.8354 11.6012C17.3336 11.6316 16.9514 12.0629 16.9817 12.5648C17.0361 13.4663 17.058 14.3571 17.0606 15.1789C17.0622 15.6817 17.4711 16.0879 17.9738 16.0863ZM17.7574 10.7566C18.2546 10.6824 18.5976 10.2192 18.5234 9.72196C18.3786 8.75184 18.1769 7.80622 17.8949 6.96589C17.735 6.48926 17.219 6.23251 16.7424 6.39242C16.2658 6.55233 16.009 7.06835 16.1689 7.54498C16.4061 8.25191 16.5877 9.08585 16.7227 9.99069C16.7969 10.4879 17.2602 10.8309 17.7574 10.7566ZM12.4025 5.5875C12.7154 5.98096 13.2881 6.04623 13.6816 5.73329C13.9241 5.54041 14.1606 5.45746 14.4262 5.46184C14.6769 5.46598 14.8935 5.54675 15.1044 5.7143C15.498 6.02704 16.0707 5.96148 16.3834 5.56785C16.6961 5.17423 16.6306 4.6016 16.237 4.28886C15.7387 3.89296 15.1406 3.65281 14.4563 3.64151C13.7196 3.62934 13.0803 3.88526 12.5483 4.30843C12.1548 4.62138 12.0896 5.19403 12.4025 5.5875Z"
+                fill={props.fill ? props.fill : "#344054"}
+            />
+            <path
+                d="M3.08635 6.75923C3.58662 6.70945 3.95181 6.26355 3.90203 5.76328C3.86241 5.3651 3.83397 5.0442 3.81548 4.82361C3.80624 4.71333 3.7995 4.62817 3.79509 4.571L3.79022 4.50662L3.78907 4.49086L3.7888 4.48721C3.7532 3.98573 3.31776 3.60727 2.81628 3.64287C2.3148 3.67847 1.93713 4.11386 1.97273 4.61534L1.97324 4.62243L1.9746 4.6409L1.97989 4.7109C1.98459 4.7719 1.99166 4.8611 2.00126 4.97561C2.02044 5.2046 2.04974 5.53498 2.0904 5.94355C2.14018 6.44382 2.58608 6.80901 3.08635 6.75923Z"
+                fill={props.fill ? props.fill : "#344054"}
+            />
+            <path
+                d="M7.48023 17.918C7.37154 17.9257 7.21585 17.8954 6.98538 17.6816C6.61678 17.3397 6.04082 17.3614 5.69894 17.73C5.35707 18.0986 5.37873 18.6746 5.74733 19.0164C6.23373 19.4676 6.86205 19.7872 7.60964 19.7339C8.44648 19.6743 9.04651 19.1778 9.45543 18.583C9.74025 18.1687 9.6353 17.602 9.22101 17.3172C8.80674 17.0324 8.24001 17.1373 7.95519 17.5516C7.7435 17.8595 7.58759 17.9103 7.48023 17.918Z"
+                fill={props.fill ? props.fill : "#344054"}
+            />
+            <path
+                d="M5.36647 16.9617C5.83443 16.778 6.06486 16.2497 5.88114 15.7817C5.60624 15.0815 5.35947 14.2667 5.14021 13.392C5.01796 12.9044 4.52354 12.6082 4.03589 12.7304C3.54824 12.8527 3.25202 13.3471 3.37427 13.8348C3.60552 14.7572 3.87422 15.6517 4.18648 16.4471C4.3702 16.915 4.8985 17.1455 5.36647 16.9617Z"
+                fill={props.fill ? props.fill : "#344054"}
+            />
+            <path
+                d="M3.874 11.9457C4.36867 11.8559 4.69694 11.3822 4.60722 10.8875C4.44765 10.0078 4.3147 9.13942 4.20555 8.33856C4.13766 7.84042 3.67881 7.49164 3.18068 7.55953C2.68254 7.62742 2.33376 8.08627 2.40165 8.58441C2.51362 9.406 2.6506 10.3013 2.81586 11.2124C2.90559 11.7071 3.37933 12.0354 3.874 11.9457Z"
+                fill={props.fill ? props.fill : "#344054"}
+            />
+            <path
+                d="M9.47756 16.2656C9.9693 16.3702 10.4527 16.0564 10.5573 15.5646C10.7484 14.6665 10.9012 13.6711 11.0466 12.6718C11.1189 12.1743 10.7743 11.7123 10.2768 11.64C9.7793 11.5676 9.31733 11.9122 9.24496 12.4097C9.09966 13.4086 8.95402 14.3516 8.77657 15.1859C8.67197 15.6776 8.98582 16.161 9.47756 16.2656Z"
+                fill={props.fill ? props.fill : "#344054"}
+            />
+            <path
+                d="M10.4223 10.5945C10.9182 10.6774 11.3873 10.3425 11.4702 9.84668C11.635 8.86005 11.8209 7.94144 12.0562 7.14817C12.1992 6.66619 11.9244 6.15955 11.4425 6.01656C10.9605 5.87357 10.4538 6.14837 10.3108 6.63034C10.0443 7.52877 9.84402 8.53197 9.67448 9.54663C9.59162 10.0425 9.92643 10.5116 10.4223 10.5945Z"
+                fill={props.fill ? props.fill : "#344054"}
+            />
+        </g>
+        <defs>
+            <clipPath id="clip0_2956_213155">
+                <rect width="24" height="24" fill="white" />
+            </clipPath>
+        </defs>
+    </SvgIcon>
+);
+export const DestinationIcon = (props: SvgIconProps) => (
+    <SvgIcon
+        {...props}
+        viewBox="0 0 24 24"
+        sx={{
+            width: props.width ? props.width : 24,
+            height: props.height ? props.height : 24,
+        }}
+    >
+        <path
+            d="M2 10.6374C2.56711 10.6374 4.35539 10.6374 4.35539 10.6374C4.71223 7.09492 6.77671 3.90601 9.92162 2.14095C10.452 1.84351 11.1222 2.03227 11.4196 2.56181C11.717 3.09157 11.5283 3.76213 10.9987 4.05957C8.22365 5.61673 6.49995 8.55858 6.49995 11.7374C6.49995 14.9159 8.22365 17.8578 10.9983 19.4149C11.5281 19.7126 11.7166 20.3827 11.4189 20.9129C11.2174 21.2724 10.8439 21.4748 10.4589 21.4748C10.2767 21.4748 10.0919 21.4295 9.92162 21.3338C6.77671 19.5689 4.71223 16.3798 4.35539 12.8374C4.35539 12.8374 2.56711 12.8374 2 12.8374C1.43289 12.8374 1 12.4747 1 11.7374C1 11 1.43289 10.6374 2 10.6374Z"
+            fill={props.fill ? props.fill : "#0C2751"}
+        />
+        <path
+            d="M22.5605 12H19.0605"
+            stroke={props.fill ? props.fill : "#0C2751"}
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        />
+        <rect
+            x="-1"
+            y="1"
+            width="8"
+            height="8"
+            rx="4"
+            transform="matrix(-1 0 0 1 17.5605 7)"
+            stroke={props.fill ? props.fill : "#0C2751"}
+            stroke-width="2"
+            fill="#fff"
+        />
+    </SvgIcon>
+);
+export const OriginIcon = (props: SvgIconProps) => (
+    <SvgIcon
+        {...props}
+        viewBox="0 0 24 24"
+        sx={{
+            width: props.width ? props.width : 24,
+            height: props.height ? props.height : 24,
+        }}
+    >
+        <path
+            d="M12 22C15 22 21 16.246 21 10.8298C21 5.41358 17.1951 1 12 1C6.80486 1 3 5.41358 3 10.8298C3 16.246 9 22 12 22ZM12 2.96596C16.158 2.96596 19.2857 6.49485 19.2857 10.8298C19.2857 15.1647 14.1429 19.766 12 19.766C9.85714 19.766 4.71429 15.1647 4.71429 10.8298C4.71429 6.49485 7.842 2.96596 12 2.96596Z"
+            fill={props.fill ? props.fill : "#344054"}
+        />
+        <circle
+            cx="12"
+            cy="11"
+            r="3"
+            stroke={props.fill ? props.fill : "#344054"}
+            stroke-width="2"
+            fill="#fff"
+        />
+    </SvgIcon>
 );

--- a/src/index.css
+++ b/src/index.css
@@ -72,3 +72,9 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+.graphContainer {
+  height: 100%;
+  width: 100%;
+  position: relative;
+}

--- a/src/models/composer.ts
+++ b/src/models/composer.ts
@@ -1,0 +1,114 @@
+export enum NodeTypes {
+    Origin = 'Origin',
+    Via = 'Via',
+    Destination = 'Destination'
+}
+
+export const TypeB60Enum = {
+    Axon: 'AXON',
+    Dendrite: 'DENDRITE'
+} as const;
+
+export type TypeB60Enum = typeof TypeB60Enum[keyof typeof TypeB60Enum];
+
+
+export const TypeC11Enum = {
+    AxonT: 'AXON-T',
+    AfferentT: 'AFFERENT-T',
+    Unknown: 'UNKNOWN'
+} as const;
+
+export type TypeC11Enum = typeof TypeC11Enum[keyof typeof TypeC11Enum];
+
+export interface AnatomicalEntity {
+    /**
+     *
+     * @type {number}
+     * @memberof AnatomicalEntity
+     */
+    'id': number;
+    /**
+     *
+     * @type {string}
+     * @memberof AnatomicalEntity
+     */
+    'name': string;
+    /**
+     *
+     * @type {string}
+     * @memberof AnatomicalEntity
+     */
+    'ontology_uri': string;
+}
+
+export interface ViaSerializerDetails {
+    /**
+     *
+     * @type {number}
+     * @memberof ViaSerializerDetails
+     */
+    'id': number;
+    /**
+     *
+     * @type {number}
+     * @memberof ViaSerializerDetails
+     */
+    'order': number;
+    /**
+     *
+     * @type {number}
+     * @memberof ViaSerializerDetails
+     */
+    'connectivity_statement_id': number;
+    /**
+     *
+     * @type {TypeB60Enum}
+     * @memberof ViaSerializerDetails
+     */
+    'type'?: TypeB60Enum;
+    /**
+     *
+     * @type {Array<AnatomicalEntity>}
+     * @memberof ViaSerializerDetails
+     */
+    'anatomical_entities': Array<AnatomicalEntity>;
+    /**
+     *
+     * @type {Array<AnatomicalEntity>}
+     * @memberof ViaSerializerDetails
+     */
+    'from_entities': Array<AnatomicalEntity>;
+}
+
+export interface DestinationSerializerDetails {
+    /**
+     *
+     * @type {number}
+     * @memberof DestinationSerializerDetails
+     */
+    'id': number;
+    /**
+     *
+     * @type {number}
+     * @memberof DestinationSerializerDetails
+     */
+    'connectivity_statement_id': number;
+    /**
+     *
+     * @type {TypeC11Enum}
+     * @memberof DestinationSerializerDetails
+     */
+    'type'?: TypeC11Enum;
+    /**
+     *
+     * @type {Array<AnatomicalEntity>}
+     * @memberof DestinationSerializerDetails
+     */
+    'anatomical_entities': Array<AnatomicalEntity>;
+    /**
+     *
+     * @type {Array<AnatomicalEntity>}
+     * @memberof DestinationSerializerDetails
+     */
+    'from_entities': Array<AnatomicalEntity>;
+}

--- a/src/resources/mockedData/MOCKED_composerStatement.ts
+++ b/src/resources/mockedData/MOCKED_composerStatement.ts
@@ -1,0 +1,206 @@
+import {TypeB60Enum, TypeC11Enum} from "../../models/composer.ts";
+
+export const MOCKED_composerStatement = {
+    "id": 280,
+    "sentence_id": 1744,
+    "sentence": {
+        "id": 1744,
+        "title": "neuron type kblad 1 created from neurondm on 20240208131816",
+        "text": "neuron type kblad 1 created from neurondm on 20240208131816",
+        "pmid": null,
+        "pmcid": null,
+        "doi": "http://uri.interlex.org/tgbugs/uris/readable/neuron-type-keast-1",
+        "batch_name": null,
+        "external_ref": null,
+        "tags": [],
+        "owner": null,
+        "owner_id": null,
+        "state": "compose_now",
+        "modified_date": "2024-02-08T13:19:01.984749",
+        "available_transitions": [
+            "completed"
+        ],
+        "connectivity_statements": [
+            {
+                "id": 280,
+                "sentence_id": 1744,
+                "knowledge_statement": "neuron type kblad 1",
+                "provenances": [
+                    {
+                        "id": 2198,
+                        "uri": "http://www.ncbi.nlm.nih.gov/pubmed/2571623",
+                        "connectivity_statement_id": 280
+                    },
+                    {
+                        "id": 2199,
+                        "uri": "http://www.ncbi.nlm.nih.gov/pubmed/7644029",
+                        "connectivity_statement_id": 280
+                    },
+                    {
+                        "id": 2200,
+                        "uri": "http://www.ncbi.nlm.nih.gov/pubmed/4700666",
+                        "connectivity_statement_id": 280
+                    },
+                    {
+                        "id": 2201,
+                        "uri": "http://www.ncbi.nlm.nih.gov/pubmed/1358408",
+                        "connectivity_statement_id": 280
+                    },
+                    {
+                        "id": 2202,
+                        "uri": "http://www.ncbi.nlm.nih.gov/pubmed/2713886",
+                        "connectivity_statement_id": 280
+                    },
+                    {
+                        "id": 2203,
+                        "uri": "http://www.ncbi.nlm.nih.gov/pubmed/30704972",
+                        "connectivity_statement_id": 280
+                    }
+                ],
+                "phenotype_id": null,
+                "phenotype": null,
+                "laterality": null,
+                "projection": null,
+                "circuit_type": null,
+                "species": [],
+                "sex_id": null,
+                "sex": null,
+                "apinatomy_model": null,
+                "additional_information": null,
+                "owner_id": 7,
+                "owner": {
+                    "id": 7,
+                    "username": "0000-0002-6119-4975",
+                    "first_name": "Afonso",
+                    "last_name": "Pinto",
+                    "email": ""
+                }
+            }
+        ],
+        "has_notes": false,
+        "pmid_uri": ".",
+        "pmcid_uri": ".",
+        "doi_uri": "https://doi.org/http://uri.interlex.org/tgbugs/uris/readable/neuron-type-keast-1"
+    },
+    "knowledge_statement": "neuron type kblad 1",
+    "tags": [],
+    "provenances": [
+        {
+            "id": 2198,
+            "uri": "http://www.ncbi.nlm.nih.gov/pubmed/2571623",
+            "connectivity_statement_id": 280
+        },
+        {
+            "id": 2199,
+            "uri": "http://www.ncbi.nlm.nih.gov/pubmed/7644029",
+            "connectivity_statement_id": 280
+        },
+        {
+            "id": 2200,
+            "uri": "http://www.ncbi.nlm.nih.gov/pubmed/4700666",
+            "connectivity_statement_id": 280
+        },
+        {
+            "id": 2201,
+            "uri": "http://www.ncbi.nlm.nih.gov/pubmed/1358408",
+            "connectivity_statement_id": 280
+        },
+        {
+            "id": 2202,
+            "uri": "http://www.ncbi.nlm.nih.gov/pubmed/2713886",
+            "connectivity_statement_id": 280
+        },
+        {
+            "id": 2203,
+            "uri": "http://www.ncbi.nlm.nih.gov/pubmed/30704972",
+            "connectivity_statement_id": 280
+        }
+    ],
+    "owner": {
+        "id": 7,
+        "username": "0000-0002-6119-4975",
+        "first_name": "Afonso",
+        "last_name": "Pinto",
+        "email": ""
+    },
+    "owner_id": 7,
+    "state": "compose_now",
+    "available_transitions": [
+        "in_progress"
+    ],
+    "origins": [
+        {
+            "id": 48411,
+            "name": "inferior hypogastric ganglion",
+            "ontology_uri": "http://purl.obolibrary.org/obo/UBERON_0016508"
+        }
+    ],
+    "vias": [
+        {
+            "id": 2541,
+            "order": 0,
+            "connectivity_statement_id": 280,
+            "type": TypeB60Enum.Axon,
+            "anatomical_entities": [
+                {
+                    "id": 59262,
+                    "name": "bladder nerve",
+                    "ontology_uri": "http://uri.interlex.org/base/ilx_0793559"
+                }
+            ],
+            "from_entities": [
+                {
+                    "id": 48411,
+                    "name": "inferior hypogastric ganglion",
+                    "ontology_uri": "http://purl.obolibrary.org/obo/UBERON_0016508"
+                }
+            ],
+            "are_connections_explicit": false
+        }
+    ],
+    "destinations": [
+        {
+            "id": 1736,
+            "connectivity_statement_id": 280,
+            "type": TypeC11Enum.AxonT,
+            "anatomical_entities": [
+                {
+                    "id": 3786,
+                    "name": "bladder neck",
+                    "ontology_uri": "http://purl.obolibrary.org/obo/UBERON_0001258"
+                }
+            ],
+            "from_entities": [
+                {
+                    "id": 3786,
+                    "name": "bladder neck",
+                    "ontology_uri": "http://purl.obolibrary.org/obo/UBERON_0001258"
+                },
+                {
+                    "id": 59262,
+                    "name": "bladder nerve",
+                    "ontology_uri": "http://uri.interlex.org/base/ilx_0793559"
+                }
+            ],
+            "are_connections_explicit": true
+        }
+    ],
+    "phenotype_id": null,
+    "phenotype": null,
+    "journey": [
+        "from inferior hypogastric ganglion to bladder neck via bladder nerve"
+    ],
+    "laterality": null,
+    "projection": null,
+    "circuit_type": null,
+    "species": [],
+    "sex_id": null,
+    "sex": null,
+    "forward_connection": [],
+    "apinatomy_model": null,
+    "additional_information": null,
+    "modified_date": "2024-03-12T15:49:42.088916",
+    "has_notes": true,
+    "statement_preview": "A connection goes from inferior hypogastric ganglion to bladder neck via bladder nerve.\nThis connection projects from the inferior hypogastric ganglion.",
+    "errors": []
+}

--- a/src/theme/variables.ts
+++ b/src/theme/variables.ts
@@ -38,4 +38,7 @@ export const vars = {
   primarypurple500S: '#9B18D8',
   gray700S: '#4B5668',
   gray100S: '#F1F2F4',
+  mediumBlue: "#548CE5",
+  lightBlue: "#E2ECFB",
+  darkBlue: "#184EA2",
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,6 +270,20 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
   integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
 
+"@emotion/react@^11.11.1":
+  version "11.11.4"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.11.4.tgz#3a829cac25c1f00e126408fab7f891f00ecc3c1d"
+  integrity sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.11.0"
+    "@emotion/cache" "^11.11.0"
+    "@emotion/serialize" "^1.1.3"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.1"
+    "@emotion/utils" "^1.2.1"
+    "@emotion/weak-memoize" "^0.3.1"
+    hoist-non-react-statics "^3.3.1"
+
 "@emotion/react@^11.11.3":
   version "11.11.3"
   resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.11.3.tgz#96b855dc40a2a55f52a72f518a41db4f69c31a25"
@@ -300,7 +314,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.2.tgz#d58e788ee27267a14342303e1abb3d508b6d0fec"
   integrity sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==
 
-"@emotion/styled@^11.11.0":
+"@emotion/styled@^11.*", "@emotion/styled@^11.11.0":
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.11.0.tgz#26b75e1b5a1b7a629d7c0a8b708fbf5a9cdce346"
   integrity sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==
@@ -767,6 +781,74 @@
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
+"@projectstorm/geometry@7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@projectstorm/geometry/-/geometry-7.0.3.tgz#0e24f56fccf38dd3fc2cc9c2899b8f04266db270"
+  integrity sha512-cwQ9IiOcLhMwVh9NsX0srcACGkpasXY1NA6659Tc9PeSYtAGySH5XC8DfL/nvPMXEdrBYS0S5zAdPC3RPcewog==
+  dependencies:
+    lodash "^4.17.21"
+
+"@projectstorm/react-canvas-core@7.0.3", "@projectstorm/react-canvas-core@^7.0.2":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@projectstorm/react-canvas-core/-/react-canvas-core-7.0.3.tgz#9151a0ce07240f71a050f568c63b9a99f4d45b62"
+  integrity sha512-Vm19AprUGx3ea0uWSMPFfpTRclaEW/7s1/hbnRDFu9WSF1VScYhw2f/cVC95qfiedip/usn4YMsg3Av6M84d0g==
+  dependencies:
+    "@emotion/react" "^11.11.1"
+    "@emotion/styled" "^11.11.0"
+    "@projectstorm/geometry" "7.0.3"
+    lodash "^4.17.21"
+    react "^18.2.0"
+
+"@projectstorm/react-diagrams-core@7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@projectstorm/react-diagrams-core/-/react-diagrams-core-7.0.3.tgz#930a12ebf665954bf5704ea4b1e6b84fdc936c3c"
+  integrity sha512-sbCy5Bk4OLfEvTtYrFK/qDc1WdgMhZzVY1rxmToVnCMP6bYiThHdopYNBX59fPHqKQebAHYER0vmlWyepqEZLQ==
+  dependencies:
+    "@emotion/styled" "^11.11.0"
+    "@projectstorm/geometry" "7.0.3"
+    "@projectstorm/react-canvas-core" "7.0.3"
+    lodash "^4.17.21"
+    react "^18.2.0"
+    resize-observer-polyfill "^1.5.1"
+
+"@projectstorm/react-diagrams-defaults@7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@projectstorm/react-diagrams-defaults/-/react-diagrams-defaults-7.1.3.tgz#a1c680a589d5f3a20cd30a3c369da1e7c24cdd07"
+  integrity sha512-T4KGgKiy4sUiH4pIq8VjR7Q+iM5SMDnVWyiwzpVFsx3D98V6r2w9qzWt3+9St/uZOKLrXj8VSCy73lmmkfNomQ==
+  dependencies:
+    "@emotion/react" "^11.11.1"
+    "@emotion/styled" "^11.*"
+    "@projectstorm/geometry" "7.0.3"
+    "@projectstorm/react-canvas-core" "7.0.3"
+    "@projectstorm/react-diagrams-core" "7.0.3"
+    lodash "^4.17.21"
+    react "^18.2.0"
+
+"@projectstorm/react-diagrams-routing@7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@projectstorm/react-diagrams-routing/-/react-diagrams-routing-7.1.3.tgz#25348377b2ad6ae7fd7b68d2ec9b75366254e70c"
+  integrity sha512-/Gbc7+8zoKQ3int6vVxoYMZ4hnqhIFwgulXUCuzYs21M7llnlaeOjOBEoifa3cNH6f8M4ht8xMhvEgg/gHiLiw==
+  dependencies:
+    "@projectstorm/geometry" "7.0.3"
+    "@projectstorm/react-canvas-core" "7.0.3"
+    "@projectstorm/react-diagrams-core" "7.0.3"
+    "@projectstorm/react-diagrams-defaults" "7.1.3"
+    dagre "^0.8.5"
+    lodash "^4.17.21"
+    pathfinding "^0.4.18"
+    paths-js "^0.4.11"
+    react "^18.2.0"
+
+"@projectstorm/react-diagrams@^7.0.3":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@projectstorm/react-diagrams/-/react-diagrams-7.0.4.tgz#9bd2e332ce5e212c222dd1864fbabf1aa95dbca4"
+  integrity sha512-GJLpo3zhJzjcmx3PfztNDTS7jpePj9TPjXV2CgJmCDZAPHDU8q/f4AyXoJfqvoWlmVnjrzQgtcOU2KbUlNu3dQ==
+  dependencies:
+    "@projectstorm/react-canvas-core" "7.0.3"
+    "@projectstorm/react-diagrams-core" "7.0.3"
+    "@projectstorm/react-diagrams-defaults" "7.1.3"
+    "@projectstorm/react-diagrams-routing" "7.1.3"
 
 "@remix-run/router@1.15.2":
   version "1.15.2"
@@ -1380,6 +1462,14 @@ csstype@^3.0.2, csstype@^3.1.3:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+dagre@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/dagre/-/dagre-0.8.5.tgz#ba30b0055dac12b6c1fcc247817442777d06afee"
+  integrity sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==
+  dependencies:
+    graphlib "^2.1.8"
+    lodash "^4.17.15"
+
 debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -1768,6 +1858,13 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+graphlib@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.8.tgz#5761d414737870084c92ec7b5dbcb0592c9d35da"
+  integrity sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==
+  dependencies:
+    lodash "^4.17.15"
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -1784,6 +1881,11 @@ hasown@^2.0.0:
   integrity sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==
   dependencies:
     function-bind "^1.1.2"
+
+heap@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.5.tgz#713b65590ebcc40fcbeeaf55e851694092b39af1"
+  integrity sha512-G7HLD+WKcrOyJP5VQwYZNC3Z6FcQ7YYjEFiFoIj8PfEr73mu421o8B1N5DKUcc8K37EsJ2XXWA8DtrDz/2dReg==
 
 hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
@@ -2051,6 +2153,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash@^4.17.15, lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -2274,6 +2381,18 @@ pathe@^1.1.0, pathe@^1.1.1, pathe@^1.1.2:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
   integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
 
+pathfinding@^0.4.18:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/pathfinding/-/pathfinding-0.4.18.tgz#a9990f6fa22b7ef196e5651b049165403a045fe8"
+  integrity sha512-R0TGEQ9GRcFCDvAWlJAWC+KGJ9SLbW4c0nuZRcioVlXVTlw+F5RvXQ8SQgSqI9KXWC1ew95vgmIiyaWTlCe9Ag==
+  dependencies:
+    heap "0.2.5"
+
+paths-js@^0.4.11:
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/paths-js/-/paths-js-0.4.11.tgz#b2a9d5f94ee9949aa8fee945f78a12abff44599e"
+  integrity sha512-3mqcLomDBXOo7Fo+UlaenG6f71bk1ZezPQy2JCmYHy2W2k5VKpP+Jbin9H0bjXynelTbglCqdFhSEkeIkKTYUA==
+
 pathval@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
@@ -2477,6 +2596,11 @@ regenerator-runtime@^0.14.0:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
   integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
+
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-from@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/ESCKAN-30

- Adds react-diagrams dependency
- Copies composer graph diagram component set
- Updates composer graph diagram component set to be compliant with more rigid linting rules
- Copies composer api types / models
- Copies icons and styles from composer
- Adds mocked statement to resources

![image](https://github.com/MetaCell/sckan-explorer/assets/19196034/3418ea02-8ba9-4e74-ba07-30bbc725ce8c)
