### PR TITLE
Feature/eskcan 46

### DIFF
--- a/src/models/explorer.ts
+++ b/src/models/explorer.ts
@@ -15,6 +15,8 @@ export interface BaseEntity {
 
 export interface Organ extends BaseEntity {
     children: Set<BaseEntity>;
+
+    order: number;
 }
 
 export interface AnatomicalEntity extends BaseEntity {

--- a/src/services/fetchService.ts
+++ b/src/services/fetchService.ts
@@ -1,6 +1,8 @@
 import {COMPOSER_API_URL, SCKAN_JSON_URL, SCKAN_MAJOR_NERVES_JSON_URL} from "../settings.ts";
 import {KnowledgeStatement} from "../models/explorer.ts";
-import {ComposerResponse, mapApiResponseToKnowledgeStatements} from "./mappers.ts";
+import {mapApiResponseToKnowledgeStatements} from "./mappers.ts";
+
+const KNOWLEDGE_STATEMENTS_BATCH_SIZE = 100
 
 export const fetchJSON = async () => {
     try {
@@ -27,23 +29,36 @@ export const fetchMajorNerves = async () => {
 };
 
 export const fetchKnowledgeStatements = async (neuronIds: string[]) => {
-    const baseUrl = `${COMPOSER_API_URL}/composer/knowledge-statement/?population_uris=${neuronIds.join(',')}`;
     let results = [] as KnowledgeStatement[];
-    let nextUrl: string | null = baseUrl;
+
+    // Helper function to create batches
+    const createBatches = (ids: string[], size: number) => {
+        const batches = [];
+        for (let i = 0; i < ids.length; i += size) {
+            batches.push(ids.slice(i, i + size));
+        }
+        return batches;
+    };
+
+    // Process each batch
+    const fetchBatch = async (batch: string[]) => {
+        const url = `${COMPOSER_API_URL}/composer/knowledge-statement/?population_uris=${batch.join(',')}`;
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+        return mapApiResponseToKnowledgeStatements(data);
+    };
 
     try {
-        while (nextUrl) {
-            const response = await fetch(nextUrl);
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-            const data: ComposerResponse = await response.json();
-            results = results.concat(mapApiResponseToKnowledgeStatements(data));
-            nextUrl = data.next;
-        }
-        return results;
+        const batches = createBatches(neuronIds, KNOWLEDGE_STATEMENTS_BATCH_SIZE);
+        const batchPromises = batches.map(batch => fetchBatch(batch));
+        const batchResults = await Promise.all(batchPromises);
+        results = batchResults.flat();
     } catch (error) {
-        console.error("Failed to fetch knowledge statements:", error);
-        return []
+        throw new Error(`Failed to fetch knowledge statements in batches:  ${error}`,);
     }
+
+    return results;
 }

--- a/src/services/heatmapService.ts
+++ b/src/services/heatmapService.ts
@@ -25,15 +25,17 @@ export function getYAxis(hierarchicalNodes: Record<string, HierarchicalNode>): H
 }
 
 export function getXAxis(organs: Record<string, Organ>): string[] {
-    return Object.values(organs).map(organ => organ.name);
+    return Object.values(organs)
+        .sort((a, b) => a.order - b.order)
+        .map(organ => organ.name);
 }
-
 
 
 export function calculateConnections(hierarchicalNodes: Record<string, HierarchicalNode>, organs: Record<string, Organ>,
                                      knowledgeStatements: Record<string, KnowledgeStatement>): Map<string, number[]> {
     // Create a map of organ IRIs to their index positions for quick lookup
-    const organIndexMap = Object.values(organs).reduce<Record<string, number>>((map, organ, index) => {
+    const sortedOrgans = Object.values(organs).sort((a, b) => a.order - b.order);
+    const organIndexMap = sortedOrgans.reduce<Record<string, number>>((map, organ, index) => {
         map[organ.id] = index;
         return map;
     }, {});

--- a/src/services/hierarchyService.ts
+++ b/src/services/hierarchyService.ts
@@ -1,5 +1,6 @@
 import {BaseEntity, HierarchicalNode, Organ} from "../models/explorer.ts";
 import {Binding, JsonData} from "../models/json.ts";
+import {OTHER_X_AXIS_ID, OTHER_X_AXIS_LABEL} from "../settings.ts";
 
 
 const PATH_DELIMITER = "#"
@@ -25,7 +26,7 @@ const PNS = {
 
 const UNK = {
     name: 'Others',
-    id: "-1",
+    id: "Others_Y_Axis_ID",
     isAncestor: (a_l1_name: string) => a_l1_name == ""
 } as RootNode
 
@@ -99,9 +100,14 @@ export const getHierarchicalNodes = (jsonData: JsonData) => {
             leafNode.connectionDetails = leafNode.connectionDetails || {};
 
             const neuronId = entry.Neuron_ID?.value;
-            const targetOrganIRI = entry.Target_Organ_IRI?.value;
+            let targetOrganIRI = entry.Target_Organ_IRI?.value;
 
-            if (neuronId && targetOrganIRI) {
+            if (neuronId) {
+                if (!targetOrganIRI) {
+                    console.warn(`Target_Organ_IRI not found for entry with Neuron_ID: ${neuronId}`);
+                    // TODO: Need to update the OTHER_X_AXIS_ID organ children
+                    targetOrganIRI = OTHER_X_AXIS_ID
+                }
                 // Ensure connectionDetails for this targetOrganIRI is initialized
                 if (!leafNode.connectionDetails[targetOrganIRI]) {
                     leafNode.connectionDetails[targetOrganIRI] = [];  // Initialize as an empty array
@@ -110,11 +116,9 @@ export const getHierarchicalNodes = (jsonData: JsonData) => {
                 // Add the KnowledgeStatement to the array for this target organ
                 leafNode.connectionDetails[targetOrganIRI].push(neuronId);
             } else {
-                if (!targetOrganIRI) {
-                    console.warn(`Target_Organ_IRI not found for entry with Neuron_ID: ${neuronId}`);
-                }
+
                 if (!neuronId) {
-                    console.warn(`Error: Neuron_ID not found for entry`);
+                    console.error(`Error: Neuron_ID not found for entry`);
                 }
             }
 
@@ -132,7 +136,7 @@ function getRootNode(a_l1_name: string): string {
 
 
 export const getOrgans = (jsonData: JsonData): Record<string, Organ> => {
-    const { bindings } = jsonData.results;
+    const {bindings} = jsonData.results;
     const organsRecord: Record<string, Organ> = {};
 
     bindings.forEach((binding: Binding) => {
@@ -143,14 +147,16 @@ export const getOrgans = (jsonData: JsonData): Record<string, Organ> => {
 
         if (organId && organName) {
             if (!organsRecord[organId]) {
-                organsRecord[organId] = { id: organId, name: organName, children: new Set<BaseEntity>() };
+                organsRecord[organId] = {id: organId, name: organName, children: new Set<BaseEntity>()};
             }
 
             if (childId && childName) {
-                organsRecord[organId].children.add({ id: childId, name: childName });
+                organsRecord[organId].children.add({id: childId, name: childName});
             }
         }
     });
+
+    organsRecord[OTHER_X_AXIS_ID] = {id: OTHER_X_AXIS_ID, name: OTHER_X_AXIS_LABEL, children: new Set<BaseEntity>()}
 
     return organsRecord;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,3 +3,6 @@ export const SCKAN_MAJOR_NERVES_JSON_URL = "https://raw.githubusercontent.com/sm
 
 export const COMPOSER_API_URL = "https://composer.sckan.dev.metacell.us/api"
 //export const COMPOSER_API_URL = import.meta.env.VITE_COMPOSER_API_URL
+
+export const OTHER_X_AXIS_ID = 'OTHER_X'
+export const OTHER_X_AXIS_LABEL = 'Other'


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/ESCKAN-46

- Updates heatmap calculation to point neurons without target organ to Other 'fictional organ'.
- Updates getOrgans to add the destination of all the neurons without target organ as children of the Other 'fictional organ'
- Adds order property to organ so we can sort them (for example in such a way that we have Other show up in the end)

Misc:
- Fix fetch knowledge statements failing due to, I believe, too big of a query string. Solution was to do the request in batches.

![image](https://github.com/MetaCell/sckan-explorer/assets/19196034/135fa555-1287-48bb-a031-36e1f00238f2)

https://github.com/MetaCell/sckan-explorer/assets/19196034/54dec5bb-64bb-48d5-9ff8-66b736a1b010

