### PR TITLE
Feature/esckan-20 - Connect Summary, Heatmap, Summary Details with table and graph views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import CssBaseline from '@mui/material/CssBaseline';
 import Header from './components/common/Header.tsx';
 import {BrowserRouter as Router, Routes, Route} from 'react-router-dom';
 import SummaryPage from "./components/SummaryPage.tsx";
+import Loader from './components/common/Loader.tsx';
 import {DataContextProvider} from './context/DataContextProvider.tsx';
 import {fetchJSON, fetchKnowledgeStatements, fetchMajorNerves} from "./services/fetchService.ts";
 import {getUniqueMajorNerves} from "./services/filterValuesService.ts";
@@ -99,7 +100,7 @@ const App = () => {
                         <Box className="MuiContainer">
                             <Routes>
                                 <Route path="/summary" element={<SummaryPage/>}/>
-                                <Route path="/" element={isLoading ? <CircularProgress/> :
+                                <Route path="/" element={isLoading ? <Loader /> :
                                     <DataContextProvider
                                         majorNerves={majorNerves}
                                         hierarchicalNodes={hierarchicalNodes}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {useDispatch, useStore} from 'react-redux';
-import {Box, CircularProgress} from "@mui/material";
+import { Box } from "@mui/material";
 import {getLayoutManagerInstance} from "@metacell/geppetto-meta-client/common/layout/LayoutManager";
 import {addWidget} from '@metacell/geppetto-meta-client/common/layout/actions';
 import {connectionsWidget, connectivityGridWidget} from "./layout-manager/widgets.ts";

--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -18,7 +18,7 @@ import Details from "./connections/Details.tsx";
 import SummaryInstructions from "./connections/SummaryInstructions.tsx";
 import PhenotypeLegend from "./connections/PhenotypeLegend.tsx";
 import HeatmapGrid from "./common/Heatmap.tsx";
-import { Organ } from "../models/explorer.ts";
+import {BaseEntity, Organ} from "../models/explorer.ts";
 
 const { gray700, gray600A, gray100 } = vars;
 
@@ -122,20 +122,19 @@ function Connections() {
 
   useEffect(() => {
     if (!checkIfConnectionSummaryIsEmpty(selectedConnectionSummary) && phenotypeFilters) {
-      const endorgans = Array.from(selectedConnectionSummary?.endOrgan.children)?.reduce((acc, organ) => {
-        acc[organ.id] = { ...organ, children: new Set(), order: 0 };  // FIXME: order 0???
-        return acc;
+      const destinations = Array.from(selectedConnectionSummary?.endOrgan.children.values()).reduce((acc, organ, index) => {
+          acc[organ.id] = { ...organ, children: new Map<string, BaseEntity>(), order: index };
+          return acc;
       }, {} as Record<string, Organ>);
 
-      const connections = calculateSecondaryConnections(hierarchicalNodes, endorgans, knowledgeStatements, summaryFilters, phenotypeFilters);
+      const connections = calculateSecondaryConnections(hierarchicalNodes, destinations, knowledgeStatements, summaryFilters, phenotypeFilters);
       setConnectionsMap(connections);
     }
   }, [hierarchicalNodes, selectedConnectionSummary, summaryFilters, knowledgeStatements, phenotypeFilters]);
 
   function getXAxisForHeatmap() {
     if (selectedConnectionSummary.endOrgan?.children) {
-      const uniqueEndOrgans = new Set(Array.from(selectedConnectionSummary.endOrgan.children).map((endOrgan) => endOrgan.name));
-      return Array.from(uniqueEndOrgans);
+      return Array.from(selectedConnectionSummary.endOrgan.children.values()).map((endOrgan) => endOrgan.name);
     }
     return []
   }
@@ -183,7 +182,7 @@ function Connections() {
             />
           )
         }
-          
+
         {showConnectionDetails === 'detailedSummary' ? (
             <>
             <Details
@@ -209,12 +208,12 @@ function Connections() {
                       <TextField value={selectedConnectionSummary?.endOrgan?.name} fullWidth />
                   </Box>
                 </Box>
-                
+
                 <Box>
                   <Typography sx={styles.heading}>Amount of connections</Typography>
                     <Chip label={totalConnectionCount + ' connections'} variant="outlined" color="primary" />
                 </Box>
-                
+
                 <Box>
                   <Typography sx={styles.heading}>Connections are through these nerves</Typography>
                     <Typography sx={styles.text}>{viasStatement}</Typography>
@@ -266,8 +265,8 @@ function Connections() {
             </>
             )
         }
-         
-          
+
+
         </Box>
     )
 }

--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -3,8 +3,7 @@ import { Box, Chip, TextField, Typography } from "@mui/material";
 import { ArrowRightIcon } from "./icons";
 import { vars } from "../theme/variables";
 import { HierarchicalItem, ISubConnections, Option, SummaryType, ksMapType } from "./common/Types";
-import { mockEntities } from "./common/MockEntities";
-import { Filters, useDataContext } from "../context/DataContext.ts";
+import { useDataContext } from "../context/DataContext.ts";
 import {
   calculateSecondaryConnections,
   checkIfConnectionSummaryIsEmpty, convertViaToString, generatePhenotypeColors,
@@ -12,14 +11,14 @@ import {
   getSecondaryHeatmapData,
   getYAxisNode
 } from "../services/summaryHeatmapService.ts";
-import { getYAxis, calculateConnections, getKnowledgeStatementAndCount } from "../services/heatmapService.ts";
+import { getYAxis, getKnowledgeStatementAndCount } from "../services/heatmapService.ts";
 import CustomFilterDropdown from "./common/CustomFilterDropdown";
 import SummaryHeader from "./connections/SummaryHeader";
 import Details from "./connections/Details.tsx";
 import SummaryInstructions from "./connections/SummaryInstructions.tsx";
 import PhenotypeLegend from "./connections/PhenotypeLegend.tsx";
 import HeatmapGrid from "./common/Heatmap.tsx";
-import { HierarchicalNode, Organ } from "../models/explorer.ts";
+import { Organ } from "../models/explorer.ts";
 
 const { gray700, gray600A, gray100 } = vars;
 
@@ -84,13 +83,6 @@ function Connections() {
   const totalConnectionCount = Object.keys(selectedConnectionSummary.connections).length;
   const phenotypes = getAllPhenotypes(selectedConnectionSummary.connections);
   const [phenotypeFilters, setPhenotypeFilters] = useState<PhenotypeDetail[]>(phenotype);
-  // const phenotypeFilters: PhenotypeDetail[] = useMemo(() => {
-  //   const phenotypeColors: string[] = generatePhenotypeColors(phenotypes.length)
-  //   return phenotypes.map((phenotype, index) => ({
-  //     label: phenotype,
-  //     color: phenotypeColors[index]
-  //   }))
-  // }, [phenotypes]);
 
   useEffect(() => {
     if (!checkIfConnectionSummaryIsEmpty(selectedConnectionSummary)) {
@@ -102,12 +94,13 @@ function Connections() {
       })))
     }
 
-  }, [])
+  }, [selectedConnectionSummary])
 
   const nerves = getNerveFilters(viasConnection, majorNerves);
 
   const searchPhenotypeFilter = (searchValue: string): Option[] => {
-    let searchedPhenotype = phenotypes
+    console.log(searchValue)
+    const searchedPhenotype = phenotypes
     return searchedPhenotype.map((phenotype) => ({
       id: phenotype,
       label: phenotype,
@@ -115,8 +108,10 @@ function Connections() {
       content: []
     }));
   }
+
   const searchNerveFilter = (searchValue: string): Option[] => {
-    let searchedNerve = Object.keys(nerves)
+    console.log(searchValue)
+    const searchedNerve = Object.keys(nerves)
     return searchedNerve.map((nerve) => ({
       id: nerve,
       label: nerves[nerve],
@@ -135,7 +130,7 @@ function Connections() {
       const connections = calculateSecondaryConnections(hierarchicalNodes, endorgans, knowledgeStatements, summaryFilters, phenotypeFilters);
       setConnectionsMap(connections);
     }
-  }, [hierarchicalNodes, selectedConnectionSummary?.endOrgan, knowledgeStatements, phenotypeFilters]);
+  }, [hierarchicalNodes, selectedConnectionSummary, summaryFilters, knowledgeStatements, phenotypeFilters]);
 
   function getXAxisForHeatmap() {
     if (selectedConnectionSummary.endOrgan?.children) {
@@ -154,12 +149,12 @@ function Connections() {
         .filter((node: HierarchicalItem) => Object.keys(node).length > 0);
       setYAxis(yNode);
     }
-  }, [selectedConnectionSummary]);
+  }, [selectedConnectionSummary, hierarchicalNodes, yAxisCon]);
 
   const heatmapData = useMemo(() => {
     const data = getSecondaryHeatmapData(yAxis, connectionsMap);
     return data;
-  }, [yAxis, xAxis, connectionsMap, selectedConnectionSummary.connections]);
+  }, [yAxis, connectionsMap]);
 
   const [uniqueKS, setUniqueKS] = useState<ksMapType>({});
 

--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Box, Chip, TextField, Typography } from "@mui/material";
 import { ArrowRightIcon } from "./icons";
 import { vars } from "../theme/variables";
-import { HierarchicalItem, ISubConnections, Option, SummaryType, KsMapType } from "./common/Types";
+import { HierarchicalItem, SubConnections, Option, SummaryType, KsMapType } from "./common/Types";
 import { useDataContext } from "../context/DataContext.ts";
 import {
   calculateSecondaryConnections,
@@ -64,7 +64,7 @@ const phenotype: PhenotypeDetail[] = [
 
 function Connections() {
   const [showConnectionDetails, setShowConnectionDetails] = useState<SummaryType>(SummaryType.Instruction);
-  const [connectionsMap, setConnectionsMap] = useState<Map<string, ISubConnections[]>>(new Map());
+  const [connectionsMap, setConnectionsMap] = useState<Map<string, SubConnections[]>>(new Map());
   const [connectionPage, setConnectionPage] = useState(1);   // represents the page number / index of the connections - if (x,y) has 4 connections, then connectionPage will be 1, 2, 3, 4
   const [yAxis, setYAxis] = useState<HierarchicalItem[]>([]);
   const [selectedCell, setSelectedCell] = useState<{ x: number, y: number } | null>(null);

--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -133,10 +133,13 @@ function Connections() {
   }, [hierarchicalNodes, selectedConnectionSummary, summaryFilters, knowledgeStatements, phenotypeFilters]);
 
   function getXAxisForHeatmap() {
-    if (selectedConnectionSummary.endOrgan?.children) {
-      return Array.from(selectedConnectionSummary.endOrgan.children.values()).map((endOrgan) => endOrgan.name);
+  const [xAxis, setXAxis] = useState<string[]>([]);
+  useEffect(() => {
+    if (selectedConnectionSummary) {
+      const xAxis = getXAxisForHeatmap(selectedConnectionSummary?.endOrgan || {} as Organ)
+      setXAxis(xAxis);
     }
-    return []
+  }, [selectedConnectionSummary]);
   }
   const xAxis = getXAxisForHeatmap()
   const yAxisCon = selectedConnectionSummary.hierarchy

--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Box, Chip, TextField, Typography } from "@mui/material";
 import { ArrowRightIcon } from "./icons";
 import { vars } from "../theme/variables";
-import { HierarchicalItem, ISubConnections, Option, SummaryType, ksMapType } from "./common/Types";
+import { HierarchicalItem, ISubConnections, Option, SummaryType, KsMapType } from "./common/Types";
 import { useDataContext } from "../context/DataContext.ts";
 import {
   calculateSecondaryConnections,
@@ -18,63 +18,63 @@ import Details from "./connections/Details.tsx";
 import SummaryInstructions from "./connections/SummaryInstructions.tsx";
 import PhenotypeLegend from "./connections/PhenotypeLegend.tsx";
 import HeatmapGrid from "./common/Heatmap.tsx";
-import {BaseEntity, Organ} from "../models/explorer.ts";
+import { BaseEntity, Organ } from "../models/explorer.ts";
 
 const { gray700, gray600A, gray100 } = vars;
 
 const styles = {
-    heading: {
-        fontSize: '0.875rem',
-        fontWeight: '500',
-        lineHeight: '1.25rem',
-        color: gray700,
-        marginBottom: '0.5rem'
-    },
-    text: {
-        fontSize: '0.875rem',
-        fontWeight: 400,
-        lineHeight: '1.25rem',
-        color: gray600A
-    }
+  heading: {
+    fontSize: '0.875rem',
+    fontWeight: '500',
+    lineHeight: '1.25rem',
+    color: gray700,
+    marginBottom: '0.5rem'
+  },
+  text: {
+    fontSize: '0.875rem',
+    fontWeight: 400,
+    lineHeight: '1.25rem',
+    color: gray600A
+  }
 }
 
 type PhenotypeDetail = {
-    label: string;
-    color: string;
+  label: string;
+  color: string;
 };
 const phenotype: PhenotypeDetail[] = [
-    {
-        label: 'Sympathetic',
-        color: '#9B18D8'
-    },
-    {
-        label: 'Parasympathetic',
-        color: '#2C2CCE'
-    },
-    {
-        label: 'Sensory',
-        color: '#DC6803'
-    },
-    {
-        label: 'Motor',
-        color: '#EAAA08'
-    }
+  {
+    label: 'Sympathetic',
+    color: '#9B18D8'
+  },
+  {
+    label: 'Parasympathetic',
+    color: '#2C2CCE'
+  },
+  {
+    label: 'Sensory',
+    color: '#DC6803'
+  },
+  {
+    label: 'Motor',
+    color: '#EAAA08'
+  }
 ]
 
 
 function Connections() {
-  const [showConnectionDetails, setShowConnectionDetails] = useState<SummaryType>('instruction');
+  const [showConnectionDetails, setShowConnectionDetails] = useState<SummaryType>(SummaryType.Instruction);
   const [connectionsMap, setConnectionsMap] = useState<Map<string, ISubConnections[]>>(new Map());
-  const [connectionCount, setConnectionCount] = useState(1);
+  const [connectionPage, setConnectionPage] = useState(1);   // represents the page number / index of the connections - if (x,y) has 4 connections, then connectionPage will be 1, 2, 3, 4
   const [yAxis, setYAxis] = useState<HierarchicalItem[]>([]);
   const [selectedCell, setSelectedCell] = useState<{ x: number, y: number } | null>(null);
 
   const { selectedConnectionSummary, majorNerves, hierarchicalNodes, knowledgeStatements, summaryFilters } = useDataContext();
   useEffect(() => {
     if (checkIfConnectionSummaryIsEmpty(selectedConnectionSummary)) {
-      setShowConnectionDetails('instruction');
+      setShowConnectionDetails(SummaryType.Instruction);
     } else {
-      setShowConnectionDetails('summary');
+      setShowConnectionDetails(SummaryType.Summary);
     }
   }, [selectedConnectionSummary])
 
@@ -123,8 +123,8 @@ function Connections() {
   useEffect(() => {
     if (!checkIfConnectionSummaryIsEmpty(selectedConnectionSummary) && phenotypeFilters) {
       const destinations = Array.from(selectedConnectionSummary?.endOrgan.children.values()).reduce((acc, organ, index) => {
-          acc[organ.id] = { ...organ, children: new Map<string, BaseEntity>(), order: index };
-          return acc;
+        acc[organ.id] = { ...organ, children: new Map<string, BaseEntity>(), order: index };
+        return acc;
       }, {} as Record<string, Organ>);
 
       const connections = calculateSecondaryConnections(hierarchicalNodes, destinations, knowledgeStatements, summaryFilters, phenotypeFilters);
@@ -155,120 +155,119 @@ function Connections() {
     return data;
   }, [yAxis, connectionsMap]);
 
-  const [uniqueKS, setUniqueKS] = useState<ksMapType>({});
+  const [uniqueKS, setUniqueKS] = useState<KsMapType>({});
 
   const handleCellClick = (x: number, y: number, yId: string): void => {
     setSelectedCell({ x, y });
-    setConnectionCount(1)
+    setConnectionPage(1)
     const row = connectionsMap.get(yId);
     if (Object.keys(selectedConnectionSummary.connections).length !== 0 && row) {
-      setShowConnectionDetails('detailedSummary');
+      setShowConnectionDetails(SummaryType.DetailedSummary)
       const ksMap = getKnowledgeStatementAndCount(row[x].ksIds, knowledgeStatements);
       setUniqueKS(ksMap)
     }
   }
-    return (
-        <Box display='flex' flexDirection='column' minHeight={1}>
-        {
-          // don't show header - for instructions
-          showConnectionDetails !== 'instruction' && (
-            <SummaryHeader
-              showDetails={showConnectionDetails}
-              setShowDetails={setShowConnectionDetails}
-              uniqueKS={uniqueKS}
-              connectionCount={connectionCount}
-              setConnectionCount={setConnectionCount}
-              totalConnectionCount={totalConnectionCount}
-            />
-          )
-        }
+  return (
+    <Box display='flex' flexDirection='column' minHeight={1}>
+      {
+        showConnectionDetails !== SummaryType.Instruction && (
+          <SummaryHeader
+            showDetails={showConnectionDetails}
+            setShowDetails={setShowConnectionDetails}
+            uniqueKS={uniqueKS}
+            connectionPage={connectionPage}
+            setConnectionPage={setConnectionPage}
+            totalConnectionCount={totalConnectionCount}
+          />
+        )
+      }
 
-        {showConnectionDetails === 'detailedSummary' ? (
-            <>
-            <Details
-              uniqueKS={uniqueKS}
-              connectionCount={connectionCount}
-            />
-          </>
-        ) : showConnectionDetails === 'instruction' ? (
-          <>
-            <SummaryInstructions />
-          </>
-        ) : (
-            <>
-              <Box p={3} display='flex' flexDirection='column' gap={3}>
-                <Box display='flex' alignItems='flex-end' gap={1.5}>
-                  <Box flex={1}>
-                    <Typography sx={{...styles.heading, marginBottom: '0.75rem'}}>Connection origin</Typography>
-                      <TextField value={selectedConnectionSummary?.origin || ''} fullWidth />
-                  </Box>
-                  <ArrowRightIcon />
-                  <Box flex={1}>
-                    <Typography sx={{...styles.heading, marginBottom: '0.75rem'}}>End Organ</Typography>
-                      <TextField value={selectedConnectionSummary?.endOrgan?.name} fullWidth />
-                  </Box>
-                </Box>
-
-                <Box>
-                  <Typography sx={styles.heading}>Amount of connections</Typography>
-                    <Chip label={totalConnectionCount + ' connections'} variant="outlined" color="primary" />
-                </Box>
-
-                <Box>
-                  <Typography sx={styles.heading}>Connections are through these nerves</Typography>
-                    <Typography sx={styles.text}>{viasStatement}</Typography>
-                </Box>
+      {showConnectionDetails === 'detailedSummary' ? (
+        <>
+          <Details
+            uniqueKS={uniqueKS}
+            connectionPage={connectionPage}
+          />
+        </>
+      ) : showConnectionDetails === SummaryType.Instruction ? (
+        <>
+          <SummaryInstructions />
+        </>
+      ) : (
+        <>
+          <Box p={3} display='flex' flexDirection='column' gap={3}>
+            <Box display='flex' alignItems='flex-end' gap={1.5}>
+              <Box flex={1}>
+                <Typography sx={{ ...styles.heading, marginBottom: '0.75rem' }}>Connection origin</Typography>
+                <TextField value={selectedConnectionSummary?.origin || ''} fullWidth />
+              </Box>
+              <ArrowRightIcon />
+              <Box flex={1}>
+                <Typography sx={{ ...styles.heading, marginBottom: '0.75rem' }}>End Organ</Typography>
+                <TextField value={selectedConnectionSummary?.endOrgan?.name} fullWidth />
+              </Box>
             </Box>
 
-            <Box display='flex' flexDirection='column' flex={1} p={3} sx={{
-                borderTop: `0.0625rem solid ${gray100}`,
-              }}>
-                <Box mb={3}>
-                  <Typography sx={{...styles.heading, fontSize: '1rem', lineHeight: '1.5rem'}}>Summary map</Typography>
-                  <Typography sx={styles.text}>
-                    Summary map shows the connections of the selected connection origin and end organ with phenotypes. Select individual squares to view the details of each connections.
-                  </Typography>
-                </Box>
-                <Box display="flex" gap={1} flexWrap='wrap'>
-                    <CustomFilterDropdown
-                        key={"Phenotype"}
-                        id={"Phenotype"}
-                        placeholder="Phenotype"
-                        searchPlaceholder="Search Phenotype"
-                        selectedOptions={[]}
-                      onSearch={(searchValue: string) => searchPhenotypeFilter(searchValue)}
-                        onSelect={() => {}}
-                    />
-                    <CustomFilterDropdown
-                        key={"Nerve"}
-                        id={"Nerve"}
-                        placeholder="Nerve"
-                        searchPlaceholder="Search Nerve"
-                        selectedOptions={[]}
-                      onSearch={(searchValue: string) => searchNerveFilter(searchValue)}
-                        onSelect={() => {}}
-                    />
-                </Box>
-                  <HeatmapGrid
-                    yAxis={yAxis}
-                    setYAxis={setYAxis}
-                    xAxis={xAxis}
-                    onCellClick={handleCellClick}
-                    selectedCell={selectedCell}
-                    secondaryHeatmapData={heatmapData}
-                    xAxisLabel={'Project to'}
-                    yAxisLabel={'Somas in'}
-                  />
-              </Box>
+            <Box>
+              <Typography sx={styles.heading}>Amount of connections</Typography>
+              <Chip label={totalConnectionCount + ' connections'} variant="outlined" color="primary" />
+            </Box>
 
-                <PhenotypeLegend phenotypes={phenotypeFilters} />
-            </>
-            )
-        }
+            <Box>
+              <Typography sx={styles.heading}>Connections are through these nerves</Typography>
+              <Typography sx={styles.text}>{viasStatement}</Typography>
+            </Box>
+          </Box>
+
+          <Box display='flex' flexDirection='column' flex={1} p={3} sx={{
+            borderTop: `0.0625rem solid ${gray100}`,
+          }}>
+            <Box mb={3}>
+              <Typography sx={{ ...styles.heading, fontSize: '1rem', lineHeight: '1.5rem' }}>Summary map</Typography>
+              <Typography sx={styles.text}>
+                Summary map shows the connections of the selected connection origin and end organ with phenotypes. Select individual squares to view the details of each connections.
+              </Typography>
+            </Box>
+            <Box display="flex" gap={1} flexWrap='wrap'>
+              <CustomFilterDropdown
+                key={"Phenotype"}
+                id={"Phenotype"}
+                placeholder="Phenotype"
+                searchPlaceholder="Search Phenotype"
+                selectedOptions={[]}
+                onSearch={(searchValue: string) => searchPhenotypeFilter(searchValue)}
+                onSelect={() => { }}
+              />
+              <CustomFilterDropdown
+                key={"Nerve"}
+                id={"Nerve"}
+                placeholder="Nerve"
+                searchPlaceholder="Search Nerve"
+                selectedOptions={[]}
+                onSearch={(searchValue: string) => searchNerveFilter(searchValue)}
+                onSelect={() => { }}
+              />
+            </Box>
+            <HeatmapGrid
+              yAxis={yAxis}
+              setYAxis={setYAxis}
+              xAxis={xAxis}
+              onCellClick={handleCellClick}
+              selectedCell={selectedCell}
+              secondaryHeatmapData={heatmapData}
+              xAxisLabel={'Project to'}
+              yAxisLabel={'Somas in'}
+            />
+          </Box>
+
+          <PhenotypeLegend phenotypes={phenotypeFilters} />
+        </>
+      )
+      }
 
 
-        </Box>
-    )
+    </Box>
+  )
 }
 
 export default Connections

--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -1,13 +1,25 @@
+import React, { useEffect, useMemo, useState } from "react";
 import { Box, Chip, TextField, Typography } from "@mui/material";
-import React, { useState } from "react";
 import { ArrowRightIcon } from "./icons";
 import { vars } from "../theme/variables";
-import SummaryHeader from "./connections/SummaryHeader";
-import CustomFilterDropdown from "./common/CustomFilterDropdown";
-import { Option } from "./common/Types";
+import { HierarchicalItem, ISubConnections, Option, SummaryType, ksMapType } from "./common/Types";
 import { mockEntities } from "./common/MockEntities";
-// import HeatmapGrid from "./common/Heatmap";
+import { Filters, useDataContext } from "../context/DataContext.ts";
+import {
+  calculateSecondaryConnections,
+  checkIfConnectionSummaryIsEmpty, convertViaToString, generatePhenotypeColors,
+  getAllPhenotypes, getAllViasFromConnections, getNerveFilters,
+  getSecondaryHeatmapData,
+  getYAxisNode
+} from "../services/summaryHeatmapService.ts";
+import { getYAxis, calculateConnections, getKnowledgeStatementAndCount } from "../services/heatmapService.ts";
+import CustomFilterDropdown from "./common/CustomFilterDropdown";
+import SummaryHeader from "./connections/SummaryHeader";
 import Details from "./connections/Details.tsx";
+import SummaryInstructions from "./connections/SummaryInstructions.tsx";
+import PhenotypeLegend from "./connections/PhenotypeLegend.tsx";
+import HeatmapGrid from "./common/Heatmap.tsx";
+import { HierarchicalNode, Organ } from "../models/explorer.ts";
 
 const { gray700, gray600A, gray100 } = vars;
 
@@ -50,247 +62,167 @@ const phenotype: PhenotypeDetail[] = [
     }
 ]
 
-// const xLabels: string[] = ["Brain", "Lungs", "Cervical", "Spinal", "Thoraic", "Kidney", "Urinary Tract"];
-// const initialList: ListItem[] = [
-//   {
-//     label: "Brain",
-//     options: [
-//       {
-//         label: "Cerebrum",
-//         options: [
-//           {
-//             label: "Frontal Lobe",
-//             options: [
-//               "Primary Motor Cortex",
-//               "Prefrontal Cortex",
-//             ],
-//             expanded: false,
-//           },
-//           {
-//             label: "Parietal Lobe",
-//             options: [
-//               "Primary Somatosensory Cortex",
-//               "Angular Gyrus",
-//             ],
-//             expanded: false,
-//           },
-//           {
-//             label: "Temporal Lobe",
-//             options: [
-//               "Primary Auditory Cortex",
-//               "Hippocampus",
-//             ],
-//             expanded: false,
-//           },
-//         ],
-//         expanded: false,
-//       },
-//       {
-//         label: "Cerebellum",
-//         options: [
-//           {
-//             label: "Anterior Lobe",
-//             options: [
-//               "Spinocerebellum",
-//               "Vestibulocerebellum",
-//             ],
-//             expanded: false,
-//           },
-//           {
-//             label: "Posterior Lobe",
-//             options: [
-//               "Neocerebellum",
-//             ],
-//             expanded: false,
-//           },
-//         ],
-//         expanded: false,
-//       },
-//       {
-//         label: "Brainstem",
-//         options: [
-//           {
-//             label: "Midbrain",
-//             options: [
-//               "Tectum",
-//               "Tegmentum",
-//             ],
-//             expanded: false,
-//           },
-//           {
-//             label: "Pons",
-//             options: [
-//               "Ventral Surface",
-//               "Dorsal Surface",
-//             ],
-//             expanded: false,
-//           },
-//           {
-//             label: "Medulla Oblongata",
-//             options: [
-//               {
-//                 label: "Pyramids",
-//                 options: [
-//                   "Corticospinal Tract",
-//                 ],
-//                 expanded: false,
-//               },
-//               {
-//                 label: "Olive",
-//                 options: [
-//                   "Inferior Olive",
-//                 ],
-//                 expanded: false,
-//               },
-//             ],
-//             expanded: false,
-//           },
-//         ],
-//         expanded: false,
-//       },
-//     ],
-//     expanded: false,
-//   },
-//   {
-//     label: "Nerves",
-//     options: [
-//       {
-//         label: "Cranial Nerves",
-//         options: [
-//           {
-//             label: "Olfactory Nerve",
-//             options: [
-//               "Olfactory Bulb",
-//             ],
-//             expanded: false,
-//           },
-//           {
-//             label: "Optic Nerve",
-//             options: [
-//               "Optic Chiasm",
-//             ],
-//             expanded: false,
-//           },
-//           {
-//             label: "Oculomotor Nerve",
-//             options: [
-//               "Superior Colliculus",
-//               "Edinger-Westphal Nucleus",
-//             ],
-//             expanded: false,
-//           },
-//         ],
-//         expanded: false,
-//       },
-//       {
-//         label: "Spinal Nerves",
-//         options: [
-//           {
-//             label: "Cervical Nerves",
-//             options: [
-//               "C1",
-//               "C2",
-//             ],
-//             expanded: false,
-//           },
-//           {
-//             label: "Thoracic Nerves",
-//             options: [
-//               // New nested options under "T1"
-//               {
-//                 label: "T1",
-//                 options: ["Sublevel 1", "Sublevel 2"],
-//                 expanded: false,
-//               },
-//               // New nested options under "T2"
-//               {
-//                 label: "T2",
-//                 options: ["Sublevel 1", "Sublevel 2"],
-//                 expanded: false,
-//               },
-//               // Add more nested options as needed
-//             ],
-//             expanded: false,
-//           },
-//           {
-//             label: "Lumbar Nerves",
-//             options: [
-//               "L1",
-//               "L2",
-//             ],
-//             expanded: false,
-//           },
-//         ],
-//         expanded: false,
-//       },
-//     ],
-//     expanded: false,
-//   },
-// ];
-
-const getEntities = (searchValue: string /* unused */): Option[] => {
-
-    console.log(`Received search value: ${searchValue}`);
-
-    // Return mockEntities or perform other logic
-    return mockEntities;
-};
-
-//
-// const initialData: number[][] = initialList.reduce((acc: number[][], item: ListItem) => {
-// const mainRow: number[] = new Array(xLabels.length)
-//     .fill(0)
-//     .map(() => Math.floor(Math.random() * 100));
-// const optionRows: number[][] = item.options.map(() =>
-//     /* remove the logic , it is just to show empty values as well */
-//     new Array(xLabels.length).fill(0).map((_, i:number) => i%3 === 0 ? Math.floor(Math.random() * 100) : 0)
-// );
-// return [...acc, mainRow, ...optionRows];
-// }, []);
-
-
 
 function Connections() {
-    // const [list, setList] = useState<ListItem[]>(initialList);
-    // const [data, setData] = useState<number[][]>(initialData);
-    const [showConnectionDetails, setShowConnectionDetails] = useState<boolean>(true);
-    
+  const [showConnectionDetails, setShowConnectionDetails] = useState<SummaryType>('instruction');
+  const [connectionsMap, setConnectionsMap] = useState<Map<string, ISubConnections[]>>(new Map());
+  const [connectionCount, setConnectionCount] = useState(1);
+  const [yAxis, setYAxis] = useState<HierarchicalItem[]>([]);
+  const [selectedCell, setSelectedCell] = useState<{ x: number, y: number } | null>(null);
+
+  const { selectedConnectionSummary, majorNerves, hierarchicalNodes, knowledgeStatements, summaryFilters } = useDataContext();
+  useEffect(() => {
+    if (checkIfConnectionSummaryIsEmpty(selectedConnectionSummary)) {
+      setShowConnectionDetails('instruction');
+    } else {
+      setShowConnectionDetails('summary');
+    }
+  }, [selectedConnectionSummary])
+
+  const viasConnection = getAllViasFromConnections(selectedConnectionSummary.connections);
+  const viasStatement = convertViaToString(Object.values(viasConnection))
+  const totalConnectionCount = Object.keys(selectedConnectionSummary.connections).length;
+  const phenotypes = getAllPhenotypes(selectedConnectionSummary.connections);
+  const [phenotypeFilters, setPhenotypeFilters] = useState<PhenotypeDetail[]>(phenotype);
+  // const phenotypeFilters: PhenotypeDetail[] = useMemo(() => {
+  //   const phenotypeColors: string[] = generatePhenotypeColors(phenotypes.length)
+  //   return phenotypes.map((phenotype, index) => ({
+  //     label: phenotype,
+  //     color: phenotypeColors[index]
+  //   }))
+  // }, [phenotypes]);
+
+  useEffect(() => {
+    if (!checkIfConnectionSummaryIsEmpty(selectedConnectionSummary)) {
+      const phenotypes = getAllPhenotypes(selectedConnectionSummary.connections);
+      const phenotypeColors: string[] = generatePhenotypeColors(phenotypes.length)
+      setPhenotypeFilters(phenotypes.map((phenotype, index) => ({
+        label: phenotype,
+        color: phenotypeColors[index]
+      })))
+    }
+
+  }, [])
+
+  const nerves = getNerveFilters(viasConnection, majorNerves);
+
+  const searchPhenotypeFilter = (searchValue: string): Option[] => {
+    let searchedPhenotype = phenotypes
+    return searchedPhenotype.map((phenotype) => ({
+      id: phenotype,
+      label: phenotype,
+      group: 'Phenotype',
+      content: []
+    }));
+  }
+  const searchNerveFilter = (searchValue: string): Option[] => {
+    let searchedNerve = Object.keys(nerves)
+    return searchedNerve.map((nerve) => ({
+      id: nerve,
+      label: nerves[nerve],
+      group: 'Nerve',
+      content: []
+    }));
+  }
+
+  useEffect(() => {
+    if (!checkIfConnectionSummaryIsEmpty(selectedConnectionSummary) && phenotypeFilters) {
+      const endorgans = Array.from(selectedConnectionSummary?.endOrgan.children)?.reduce((acc, organ) => {
+        acc[organ.id] = { ...organ, children: new Set(), order: 0 };  // FIXME: order 0???
+        return acc;
+      }, {} as Record<string, Organ>);
+
+      const connections = calculateSecondaryConnections(hierarchicalNodes, endorgans, knowledgeStatements, summaryFilters, phenotypeFilters);
+      setConnectionsMap(connections);
+    }
+  }, [hierarchicalNodes, selectedConnectionSummary?.endOrgan, knowledgeStatements, phenotypeFilters]);
+
+  function getXAxisForHeatmap() {
+    if (selectedConnectionSummary.endOrgan?.children) {
+      const uniqueEndOrgans = new Set(Array.from(selectedConnectionSummary.endOrgan.children).map((endOrgan) => endOrgan.name));
+      return Array.from(uniqueEndOrgans);
+    }
+    return []
+  }
+  const xAxis = getXAxisForHeatmap()
+  const yAxisCon = selectedConnectionSummary.hierarchy
+
+  useEffect(() => {
+    if (!checkIfConnectionSummaryIsEmpty(selectedConnectionSummary)) {
+      const yAxis = getYAxis(hierarchicalNodes);
+      const yNode = yAxis.map((node: HierarchicalItem) => getYAxisNode(node, yAxisCon))
+        .filter((node: HierarchicalItem) => Object.keys(node).length > 0);
+      setYAxis(yNode);
+    }
+  }, [selectedConnectionSummary]);
+
+  const heatmapData = useMemo(() => {
+    const data = getSecondaryHeatmapData(yAxis, connectionsMap);
+    return data;
+  }, [yAxis, xAxis, connectionsMap, selectedConnectionSummary.connections]);
+
+  const [uniqueKS, setUniqueKS] = useState<ksMapType>({});
+
+  const handleCellClick = (x: number, y: number, yId: string): void => {
+    setSelectedCell({ x, y });
+    setConnectionCount(1)
+    const row = connectionsMap.get(yId);
+    if (Object.keys(selectedConnectionSummary.connections).length !== 0 && row) {
+      setShowConnectionDetails('detailedSummary');
+      const ksMap = getKnowledgeStatementAndCount(row[x].ksIds, knowledgeStatements);
+      setUniqueKS(ksMap)
+    }
+  }
     return (
         <Box display='flex' flexDirection='column' minHeight={1}>
-          <SummaryHeader
-            showDetails={showConnectionDetails}
-            setShowDetails={setShowConnectionDetails}
-            numOfConnections={5}
-            connection='ilxtr:neuron-type-aacar-11'
-          />
+        {
+          // don't show header - for instructions
+          showConnectionDetails !== 'instruction' && (
+            <SummaryHeader
+              showDetails={showConnectionDetails}
+              setShowDetails={setShowConnectionDetails}
+              uniqueKS={uniqueKS}
+              connectionCount={connectionCount}
+              setConnectionCount={setConnectionCount}
+              totalConnectionCount={totalConnectionCount}
+            />
+          )
+        }
           
-          {showConnectionDetails ?
+        {showConnectionDetails === 'detailedSummary' ? (
             <>
-              <Details />
-            </>
-            :
+            <Details
+              uniqueKS={uniqueKS}
+              connectionCount={connectionCount}
+            />
+          </>
+        ) : showConnectionDetails === 'instruction' ? (
+          <>
+            <SummaryInstructions />
+          </>
+        ) : (
             <>
               <Box p={3} display='flex' flexDirection='column' gap={3}>
                 <Box display='flex' alignItems='flex-end' gap={1.5}>
                   <Box flex={1}>
                     <Typography sx={{...styles.heading, marginBottom: '0.75rem'}}>Connection origin</Typography>
-                    <TextField value='Thoracic' fullWidth />
+                      <TextField value={selectedConnectionSummary?.origin || ''} fullWidth />
                   </Box>
                   <ArrowRightIcon />
                   <Box flex={1}>
                     <Typography sx={{...styles.heading, marginBottom: '0.75rem'}}>End Organ</Typography>
-                    <TextField value='Heart' fullWidth />
+                      <TextField value={selectedConnectionSummary?.endOrgan?.name} fullWidth />
                   </Box>
                 </Box>
                 
                 <Box>
                   <Typography sx={styles.heading}>Amount of connections</Typography>
-                  <Chip label="23 connections" variant="outlined" color="primary" />
+                    <Chip label={totalConnectionCount + ' connections'} variant="outlined" color="primary" />
                 </Box>
                 
                 <Box>
                   <Typography sx={styles.heading}>Connections are through these nerves</Typography>
-                  <Typography sx={styles.text}>Pudendal, vagus and splanchnic</Typography>
+                    <Typography sx={styles.text}>{viasStatement}</Typography>
                 </Box>
             </Box>
 
@@ -310,7 +242,7 @@ function Connections() {
                         placeholder="Phenotype"
                         searchPlaceholder="Search Phenotype"
                         selectedOptions={[]}
-                        onSearch={(searchValue: string) => getEntities(searchValue)}
+                      onSearch={(searchValue: string) => searchPhenotypeFilter(searchValue)}
                         onSelect={() => {}}
                     />
                     <CustomFilterDropdown
@@ -319,64 +251,26 @@ function Connections() {
                         placeholder="Nerve"
                         searchPlaceholder="Search Nerve"
                         selectedOptions={[]}
-                        onSearch={(searchValue: string) => getEntities(searchValue)}
+                      onSearch={(searchValue: string) => searchNerveFilter(searchValue)}
                         onSelect={() => {}}
                     />
                 </Box>
-                {/*<HeatmapGrid secondary yAxisLabels={list} data={data} xAxisLabel={xLabels} setYAxis={setList} setXAxis={setData} xAxisLabel={'Project to'} yAxisLabel={'Somas in'} />*/}
+                  <HeatmapGrid
+                    yAxis={yAxis}
+                    setYAxis={setYAxis}
+                    xAxis={xAxis}
+                    onCellClick={handleCellClick}
+                    selectedCell={selectedCell}
+                    secondaryHeatmapData={heatmapData}
+                    xAxisLabel={'Project to'}
+                    yAxisLabel={'Somas in'}
+                  />
               </Box>
-              
-              <Box sx={{
-                position: 'sticky',
-                bottom: 0,
-                padding: '0 1.5rem',
-                background: '#fff'
-              }}>
-                <Box sx={{
-                  borderTop: `0.0625rem solid ${gray100}`,
-                  padding: '0.9375rem 0',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between'
-                }}>
-                  <Typography sx={{
-                    fontSize: '0.75rem',
-                    fontWeight: 500,
-                    lineHeight: '1.125rem',
-                    color: '#818898'
-                  }}>Phenotype</Typography>
-                  
-                  <Box sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '1.5rem'
-                  }}>
-                    {phenotype.map((type: PhenotypeDetail) => (
-                      <Box sx={{
-                        p: '0.1875rem 0.25rem',
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.375rem'
-                      }}>
-                        <Box sx={{
-                          width: '1.4794rem',
-                          height: '1rem',
-                          borderRadius: '0.125rem',
-                          background: type.color
-                        }} />
-                        <Typography sx={{
-                          fontSize: '0.75rem',
-                          fontWeight: 400,
-                          lineHeight: '1.125rem',
-                          color: '#4A4C4F'
-                        }}>{type.label}</Typography>
-                      </Box>
-                    ))}
-                  </Box>
-                </Box>
-              </Box>
+
+                <PhenotypeLegend phenotypes={phenotypeFilters} />
             </>
-          }
+            )
+        }
          
           
         </Box>

--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Box, Chip, TextField, Typography } from "@mui/material";
 import { ArrowRightIcon } from "./icons";
 import { vars } from "../theme/variables";
-import { HierarchicalItem, SubConnections, PhenotypeDetail, SummaryType, KsMapType, LabelIdPair } from "./common/Types";
+import { HierarchicalItem, SubConnections, PhenotypeDetail, SummaryType, KsMapType } from "./common/Types";
 import { useDataContext } from "../context/DataContext.ts";
 import {
   calculateSecondaryConnections,
@@ -10,15 +10,13 @@ import {
   getAllPhenotypes, getAllViasFromConnections, getNerveFilters,
   getSecondaryHeatmapData,
   getXAxisForHeatmap,
-  getYAxisNode
 } from "../services/summaryHeatmapService.ts";
-import { getYAxis, getKnowledgeStatementMap, generateYLabelsAndIds } from "../services/heatmapService.ts";
-import CustomFilterDropdown from "./common/CustomFilterDropdown";
+import { getYAxis, getKnowledgeStatementMap } from "../services/heatmapService.ts";
 import SummaryHeader from "./connections/SummaryHeader";
 import SummaryInstructions from "./connections/SummaryInstructions.tsx";
 import PhenotypeLegend from "./connections/PhenotypeLegend.tsx";
 import HeatmapGrid from "./common/Heatmap.tsx";
-import { BaseEntity, HierarchicalNode, Organ } from "../models/explorer.ts";
+import { BaseEntity, Organ } from "../models/explorer.ts";
 import SummaryDetails from "./connections/SummaryDetails.tsx";
 import SummaryFiltersDropdown from "./SummaryFiltersDropdown.tsx";
 

--- a/src/components/ConnectivityGrid.tsx
+++ b/src/components/ConnectivityGrid.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Typography } from "@mui/material";
 import React, {useEffect, useMemo, useState} from "react";
 import {vars} from "../theme/variables";
 import HeatmapGrid from "./common/Heatmap";
-import { SummaryFilters, useDataContext } from "../context/DataContext.ts";
+import { useDataContext } from "../context/DataContext.ts";
 import {
     calculateConnections, getMinMaxConnections, getHierarchyFromId,
     getXAxisOrgans, getYAxis, getHeatmapData,

--- a/src/components/ConnectivityGrid.tsx
+++ b/src/components/ConnectivityGrid.tsx
@@ -57,6 +57,7 @@ function ConnectivityGrid() {
     }, [yAxis, connectionsMap]);
 
     const handleClick = (x: number, y: number, yId: string): void => {
+        // When the primary heatmap cell is clicked - this sets the react-context state for Connections in SummaryType.summary
         setSelectedCell({ x, y });
         const row = connectionsMap.get(yId);
         if (row) {

--- a/src/components/ConnectivityGrid.tsx
+++ b/src/components/ConnectivityGrid.tsx
@@ -25,6 +25,7 @@ function ConnectivityGrid() {
     const [connectionsMap, setConnectionsMap] = useState<Map<string, Set<string>[]>>(new Map());
     const [selectedCell, setSelectedCell] = useState<{ x: number, y: number } | null>(null);
     const [detailedHeatmapData, setDetailedHeatmapData] = useState<DetailedHeatmapData>([]);
+    const [heatmapData, setHeatmapData] = useState<number[][]>([]);
 
     // Convert hierarchicalNodes to hierarchicalItems
     useEffect(() => {
@@ -51,12 +52,9 @@ function ConnectivityGrid() {
     }, [hierarchicalNodes]);
 
     useEffect(() => {
-        const detailedHeatmap = getHeatmapData(yAxis, connectionsMap).detailedHeatmap;
-        setDetailedHeatmapData(detailedHeatmap);
-    }, [yAxis, connectionsMap]);
-
-    const heatmapData = useMemo(() => {
-        return getHeatmapData(yAxis, connectionsMap).heatmapMatrix;
+        const heatmapdata = getHeatmapData(yAxis, connectionsMap);
+        setHeatmapData(heatmapdata.heatmapMatrix);
+        setDetailedHeatmapData(heatmapdata.detailedHeatmap);
     }, [yAxis, connectionsMap]);
 
 

--- a/src/components/ConnectivityGrid.tsx
+++ b/src/components/ConnectivityGrid.tsx
@@ -7,10 +7,9 @@ import {
     calculateConnections, getMinMaxConnections, getHierarchyFromId,
     getXAxisOrgans, getYAxis, getHeatmapData,
     getKnowledgeStatementMap,
-    generateYLabelsAndIds
 } from "../services/heatmapService.ts";
 import FiltersDropdowns from "./FiltersDropdowns.tsx";
-import { DetailedHeatmapData, HierarchicalItem } from "./common/Types.ts";
+import { HierarchicalItem } from "./common/Types.ts";
 import { Organ } from "../models/explorer.ts";
 import Loader from "./common/Loader.tsx";
 

--- a/src/components/ConnectivityGrid.tsx
+++ b/src/components/ConnectivityGrid.tsx
@@ -1,26 +1,20 @@
-import {Box, Button, CircularProgress, Typography} from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 import React, {useEffect, useMemo, useState} from "react";
 import {vars} from "../theme/variables";
 import HeatmapGrid from "./common/Heatmap";
-import {useDataContext} from "../context/DataContext.ts";
+import { SummaryFilters, useDataContext } from "../context/DataContext.ts";
 import {
     calculateConnections, getMinMaxConnections, getHierarchyFromId,
     getXAxisOrgans, getYAxis, getHeatmapData,
     getKnowledgeStatementAndCount
 } from "../services/heatmapService.ts";
 import FiltersDropdowns from "./FiltersDropdowns.tsx";
-import { DetailedHeatmapData } from "./common/Types.ts";
+import { DetailedHeatmapData, HierarchicalItem } from "./common/Types.ts";
 import { Organ } from "../models/explorer.ts";
+import Loader from "./common/Loader.tsx";
 
-export interface HierarchicalItem {
-    id: string;
-    label: string;
-    children: HierarchicalItem[];
-    expanded: boolean;
-}
 
 const {gray500, white: white, gray25, gray100, primaryPurple600, gray400} = vars;
-
 
 
 function ConnectivityGrid() {
@@ -69,8 +63,7 @@ function ConnectivityGrid() {
     const handleClick = (x: number, y: number, yId: string): void => {
         setSelectedCell({ x, y });
         const row = connectionsMap.get(yId);
-        if(row){
-            console.log(row[x])
+        if (row) {
             const endOrgan = xAxisOrgans[x];
             const origin = detailedHeatmapData[y];
             const hierarchy = getHierarchyFromId(origin.id, hierarchicalNodes);
@@ -87,7 +80,7 @@ function ConnectivityGrid() {
 
     const isLoading = yAxis.length == 0
 
-    return (isLoading ? <CircularProgress/> : (
+    return (isLoading ? <Loader /> : (
         <Box minHeight='100%' p={3} pb={0} fontSize={14} display='flex' flexDirection='column'>
             <Box pb={2.5}>
                 <Typography variant="h6" sx={{fontWeight: 400}}>Connection Origin to End Organ</Typography>
@@ -98,7 +91,7 @@ function ConnectivityGrid() {
             <HeatmapGrid
                 yAxis={yAxis}
                 setYAxis={setYAxis}
-                heatmapData={heatmapData}
+                heatmapData={heatmapData || []}
                 xAxis={xAxis}
                 xAxisLabel={'End organ'} yAxisLabel={'Connection Origin'}
                 onCellClick={handleClick}

--- a/src/components/FiltersDropdowns.tsx
+++ b/src/components/FiltersDropdowns.tsx
@@ -2,7 +2,7 @@ import {Box} from "@mui/material";
 import CustomFilterDropdown from "./common/CustomFilterDropdown.tsx";
 import React, {useMemo} from "react";
 import {Filters, useDataContext} from "../context/DataContext.ts";
-import {Option} from "./common/Types.ts";
+import { Option } from "./common/Types.ts";
 import {
     getUniqueApinatomies, getUniqueOrgans,
     getUniqueOrigins,
@@ -16,7 +16,6 @@ import {
     searchPhenotypes,
     searchSpecies, searchVias
 } from "../services/searchService.ts";
-
 
 interface FilterConfig {
     id: keyof Filters;

--- a/src/components/SummaryFiltersDropdown.tsx
+++ b/src/components/SummaryFiltersDropdown.tsx
@@ -40,7 +40,6 @@ const SummaryFiltersDropdown = ({ nerves, phenotypes }: {
 		}));
 	}
 	const convertPhenotypesToOptions = (phenotypes: PhenotypeType): Option[] => {
-		// filter the phenotype where label is other
 		return Object.values(phenotypes).map(phenotype => ({
 			id: phenotype.label,
 			label: phenotype.label,

--- a/src/components/SummaryFiltersDropdown.tsx
+++ b/src/components/SummaryFiltersDropdown.tsx
@@ -1,0 +1,85 @@
+import { useMemo } from "react";
+import { SummaryFilters, useDataContext } from "../context/DataContext";
+import CustomFilterDropdown from "./common/CustomFilterDropdown";
+import { Option, PhenotypeDetail } from "./common/Types";
+import { Box } from "@mui/material";
+import { searchNerveFilter, searchPhenotypeFilter } from "../services/searchService";
+import { OTHER_PHENOTYPE_LABEL } from "../settings";
+
+interface FilterConfig {
+	id: keyof SummaryFilters;
+	placeholder: string;
+	searchPlaceholder: string;
+}
+
+const filterConfig: FilterConfig[] = [
+	{
+		id: "Phenotype",
+		placeholder: "Phenotype",
+		searchPlaceholder: "Search phenotype",
+	},
+	{
+		id: "Nerve",
+		placeholder: "Nerve",
+		searchPlaceholder: "Search Nerve",
+	}
+]
+
+const SummaryFiltersDropdown = ({ nerves, phenotypes }: {
+	nerves: { [key: string]: string },
+	phenotypes: PhenotypeDetail[]
+}) => {
+	const { summaryFilters, setSummaryFilters } = useDataContext();
+
+	const convertNervesToOptions = (nerves: { [key: string]: string }): Option[] => {
+		return Object.keys(nerves).map(nerve => ({
+			id: nerve,
+			label: nerves[nerve],
+			group: 'Nerve',
+			content: []
+		}));
+	}
+	const convertPhenotypesToOptions = (phenotypes: PhenotypeDetail[]): Option[] => {
+		// filter the phenotype where label is other
+		return phenotypes.map(phenotype => ({
+			id: phenotype.label,
+			label: phenotype.label,
+			group: 'Phenotype',
+			content: []
+		})).filter(phenotype => phenotype.label !== OTHER_PHENOTYPE_LABEL);
+	}
+
+	const phenotypeOptions = useMemo(() => convertPhenotypesToOptions(phenotypes), [phenotypes]);
+	const nerveOptions = useMemo(() => convertNervesToOptions(nerves), [nerves]);
+
+	const handleSelect = (filterKey: keyof typeof summaryFilters, selectedOptions: Option[]) => {
+		setSummaryFilters(prevFilters => ({
+			...prevFilters,
+			[filterKey]: selectedOptions
+		}));
+	};
+
+	const searchFunctions = {
+		Phenotype: (value: string) => searchPhenotypeFilter(value, phenotypeOptions),
+		Nerve: (value: string) => searchNerveFilter(value, nerveOptions)
+	};
+
+	return (
+		<Box display="flex" gap={1} flexWrap="wrap">
+			{filterConfig.map(filter => (
+				<CustomFilterDropdown
+					key={filter.id}
+					id={filter.id}
+					placeholder={filter.placeholder}
+					searchPlaceholder={filter.searchPlaceholder}
+					selectedOptions={summaryFilters[filter.id]}
+					onSearch={(searchValue: string) => searchFunctions[filter.id](searchValue)}
+					onSelect={(options: Option[]) => handleSelect(filter.id as keyof SummaryFilters, options)}
+				/>
+			))}
+		</Box>
+	)
+
+}
+
+export default SummaryFiltersDropdown;

--- a/src/components/SummaryFiltersDropdown.tsx
+++ b/src/components/SummaryFiltersDropdown.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { SummaryFilters, useDataContext } from "../context/DataContext";
 import CustomFilterDropdown from "./common/CustomFilterDropdown";
-import { Option, PhenotypeDetail } from "./common/Types";
+import { Option, PhenotypeType } from "./common/Types";
 import { Box } from "@mui/material";
 import { searchNerveFilter, searchPhenotypeFilter } from "../services/searchService";
 import { OTHER_PHENOTYPE_LABEL } from "../settings";
@@ -27,7 +27,7 @@ const filterConfig: FilterConfig[] = [
 
 const SummaryFiltersDropdown = ({ nerves, phenotypes }: {
 	nerves: { [key: string]: string },
-	phenotypes: PhenotypeDetail[]
+	phenotypes: PhenotypeType
 }) => {
 	const { summaryFilters, setSummaryFilters } = useDataContext();
 
@@ -39,9 +39,9 @@ const SummaryFiltersDropdown = ({ nerves, phenotypes }: {
 			content: []
 		}));
 	}
-	const convertPhenotypesToOptions = (phenotypes: PhenotypeDetail[]): Option[] => {
+	const convertPhenotypesToOptions = (phenotypes: PhenotypeType): Option[] => {
 		// filter the phenotype where label is other
-		return phenotypes.map(phenotype => ({
+		return Object.values(phenotypes).map(phenotype => ({
 			id: phenotype.label,
 			label: phenotype.label,
 			group: 'Phenotype',

--- a/src/components/SummaryPage.tsx
+++ b/src/components/SummaryPage.tsx
@@ -1,11 +1,12 @@
 import React, {useState, useEffect} from "react";
-import {Box, CircularProgress, Divider, Stack, Tab, Tabs, Typography} from "@mui/material";
+import { Box, Divider, Stack, Tab, Tabs, Typography } from "@mui/material";
 import { vars } from "../theme/variables.ts";
 import {Detail} from "./summaryPage/Detail.tsx";
 import {Section} from "./summaryPage/Section.tsx";
 import {Notes} from "./summaryPage/Notes.tsx";
 import {TabPanel} from "./summaryPage/TabPanel.tsx";
 import InfoTab from "./summaryPage/InfoTab.tsx";
+import Loader from "./common/Loader.tsx";
 
 interface DataType {
   [key: string]: {
@@ -48,7 +49,7 @@ const SummaryPage = () => {
   }, []);
 
   if (!data || !labels) return <Box display='flex' justifyContent='center' alignItems='center' width={1}>
-    <CircularProgress />
+    <Loader />
   </Box>
   return (
     <Box width={1} className='database-summary'>

--- a/src/components/common/CollapsibleList.tsx
+++ b/src/components/common/CollapsibleList.tsx
@@ -2,7 +2,7 @@ import React, { FC } from "react";
 import { Box, Button } from "@mui/material";
 import { MinusIcon, PlusIcon } from "../icons";
 import { vars } from "../../theme/variables";
-import {HierarchicalItem} from "../ConnectivityGrid.tsx";
+import { HierarchicalItem } from "./Types";
 const { gray700, gray100, gray50, primaryPurple500, gray25, gray200, primaryPurple700 } = vars;
 
 

--- a/src/components/common/CustomFilterDropdown.tsx
+++ b/src/components/common/CustomFilterDropdown.tsx
@@ -26,7 +26,7 @@ const {
 } = vars;
 
 
-type Option = {
+export type Option = {
     id: string;
     label: string;
     group: string;

--- a/src/components/common/Heatmap.tsx
+++ b/src/components/common/Heatmap.tsx
@@ -4,7 +4,7 @@ import { vars } from "../../theme/variables";
 import CollapsibleList from "./CollapsibleList";
 import HeatMap from "react-heatmap-grid";
 import HeatmapTooltip from "./HeatmapTooltip";
-import { HierarchicalItem, ISubConnections } from "./Types.ts";
+import { HierarchicalItem, SubConnections } from "./Types.ts";
 import { getNormalizedValueForMinMax } from "../../services/summaryHeatmapService.ts";
 import { getPhenotypeColors } from "../../services/heatmapService.ts";
 
@@ -37,10 +37,10 @@ interface HeatmapGridProps {
     yAxisLabel?: string;
     selectedCell?: { x: number, y: number } | null;
     heatmapData?: number[][];
-    secondaryHeatmapData?: ISubConnections[][];
+    secondaryHeatmapData?: SubConnections[][];
 }
 
-const prepareSecondaryHeatmapData = (data?: ISubConnections[][]): number[][] => {
+const prepareSecondaryHeatmapData = (data?: SubConnections[][]): number[][] => {
     if (!data) return [];
     // Counts the size of the secondary heatmap cell
     return data.map(row => row.map(cell => cell.ksIds.size));
@@ -82,7 +82,7 @@ const HeatmapGrid: FC<HeatmapGridProps> = ({
         _y: number
     ) => {
         if (secondary && secondaryHeatmapData && secondaryHeatmapData[_y] && secondaryHeatmapData[_y][_x]) {
-            const phenotypeColors = secondaryHeatmapData[_y][_x]?.color;
+            const phenotypeColors = secondaryHeatmapData[_y][_x]?.colors;
             const phenotypeColor = getPhenotypeColors(normalizedValue, phenotypeColors);
 
             return phenotypeColor ? phenotypeColor : `rgba(131, 0, 191, ${normalizedValue})`;

--- a/src/components/common/Heatmap.tsx
+++ b/src/components/common/Heatmap.tsx
@@ -4,7 +4,7 @@ import { vars } from "../../theme/variables";
 import CollapsibleList from "./CollapsibleList";
 import HeatMap from "react-heatmap-grid";
 import HeatmapTooltip from "./HeatmapTooltip";
-import { HierarchicalItem, PhenotypeType, SubConnections } from "./Types.ts";
+import { HierarchicalItem, PhenotypeType, PhenotypeKsIdMap } from "./Types.ts";
 import { getNormalizedValueForMinMax } from "../../services/summaryHeatmapService.ts";
 import { generateYLabelsAndIds, getPhenotypeColors } from "../../services/heatmapService.ts";
 import { OTHER_PHENOTYPE_LABEL } from "../../settings.ts";
@@ -21,11 +21,11 @@ interface HeatmapGridProps {
     yAxisLabel?: string;
     selectedCell?: { x: number, y: number } | null;
     heatmapData?: number[][];
-    secondaryHeatmapData?: SubConnections[][];
+    secondaryHeatmapData?: PhenotypeKsIdMap[][];
     phenotypes?: PhenotypeType;
 }
 
-const prepareSecondaryHeatmapData = (data?: SubConnections[][]): number[][] => {
+const prepareSecondaryHeatmapData = (data?: PhenotypeKsIdMap[][]): number[][] => {
     if (!data) return [];
     return data.map(row => row.map(cell => cell.ksIds.size));
 }
@@ -72,11 +72,12 @@ const HeatmapGrid: FC<HeatmapGridProps> = ({
         _x: number,
         _y: number
     ) => {
+        // Gets the color for secondary heatmap cell based on the phenotypes
         if (phenotypes && secondary && secondaryHeatmapData && secondaryHeatmapData[_y] && secondaryHeatmapData[_y][_x]) {
-            const matrixCellPhenotypes = secondaryHeatmapData[_y][_x]?.phenotypes;
+            const heatmapCellPhenotypes = secondaryHeatmapData[_y][_x]?.phenotypes;
 
             const phenotypeColorsSet = new Set<string>();
-            matrixCellPhenotypes.forEach(phenotype => {
+            heatmapCellPhenotypes.forEach(phenotype => {
                 const phnColor = phenotypes[phenotype]?.color
                 if (phnColor) {
                     phenotypeColorsSet.add(phnColor);

--- a/src/components/common/Heatmap.tsx
+++ b/src/components/common/Heatmap.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo, } from "react";
+import React, { FC, useCallback, useMemo, } from "react";
 import { Box, Typography } from "@mui/material";
 import { vars } from "../../theme/variables";
 import CollapsibleList from "./CollapsibleList";
@@ -24,11 +24,10 @@ interface HeatmapGridProps {
 }
 
 const prepareSecondaryHeatmapData = (data?: SubConnections[][]): number[][] => {
-    return useMemo(() => {
-        if (!data) return [];
-        return data.map(row => row.map(cell => cell.ksIds.size));
-    }, [data])
+    if (!data) return [];
+    return data.map(row => row.map(cell => cell.ksIds.size));
 }
+
 
 const HeatmapGrid: FC<HeatmapGridProps> = ({
     xAxis, yAxis, setYAxis,
@@ -36,8 +35,12 @@ const HeatmapGrid: FC<HeatmapGridProps> = ({
     onCellClick, selectedCell, heatmapData, secondaryHeatmapData
 }) => {
     const secondary = secondaryHeatmapData ? true : false;
-    const heatmapMatrixData = secondary ? prepareSecondaryHeatmapData(secondaryHeatmapData) : heatmapData;
-    const handleCollapseClick = (item: HierarchicalItem) => {
+
+    const heatmapMatrixData = useMemo(() => {
+        return secondary ? prepareSecondaryHeatmapData(secondaryHeatmapData) : heatmapData;
+    }, [secondary, secondaryHeatmapData, heatmapData]);
+
+    const handleCollapseClick = useCallback((item: HierarchicalItem) => {
         const updateList = (list: HierarchicalItem[], selectedItem: HierarchicalItem): HierarchicalItem[] => {
             return list?.map(listItem => {
                 if (listItem.label === selectedItem.label) {
@@ -50,9 +53,11 @@ const HeatmapGrid: FC<HeatmapGridProps> = ({
         };
         const updatedList = updateList(yAxis, item);
         setYAxis(updatedList);
-    };
+    }, [yAxis, setYAxis]);
 
     const yAxisData = generateYLabelsAndIds(yAxis);
+
+
 
     const handleCellClick = (x: number, y: number) => {
         const ids = yAxisData.ids

--- a/src/components/common/Heatmap.tsx
+++ b/src/components/common/Heatmap.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo, useState } from "react";
+import React, { FC } from "react";
 import { Box, Typography } from "@mui/material";
 import { vars } from "../../theme/variables";
 import CollapsibleList from "./CollapsibleList";
@@ -8,7 +8,7 @@ import { HierarchicalItem, ISubConnections } from "./Types.ts";
 import { getNormalizedValueForMinMax } from "../../services/summaryHeatmapService.ts";
 
 
-const { gray50, primaryPurple500, gray25, gray100A, gray500 } = vars;
+const { gray50, primaryPurple500, gray100A, gray500 } = vars;
 
 
 const generateYLabelsAndIds = (list: HierarchicalItem[], prefix = ''): { labels: string[], ids: string[] } => {
@@ -78,10 +78,7 @@ const HeatmapGrid: FC<HeatmapGridProps> = ({
     const getCellBgColorFromPhenotype = (
         normalizedValue: number,
         _x: number,
-        _y: number,
-        value: number,
-        min: number,
-        max: number
+        _y: number
     ) => {
         if (secondary && secondaryHeatmapData && secondaryHeatmapData[_y] && secondaryHeatmapData[_y][_x]) {
             const phenotypeColors = secondaryHeatmapData[_y][_x]?.color;
@@ -238,8 +235,7 @@ const HeatmapGrid: FC<HeatmapGridProps> = ({
                                     background: getCellBgColorFromPhenotype(
                                         safeNormalizedValue,
                                         _x,
-                                        _y,
-                                        value, min, max
+                                        _y
                                     )
                                 }
                             } else {
@@ -256,7 +252,7 @@ const HeatmapGrid: FC<HeatmapGridProps> = ({
                         cellRender={(value: number, x: number, y: number) => (
                             <HeatmapTooltip
                                 value={value} x={x} y={y}
-                                secondary={secondary} getCellBgColor={(value) => 'rgba(0,0,0,0)'}
+                                secondary={secondary} getCellBgColor={() => 'rgba(0,0,0,0)'}
                             />
                         )}
                     />

--- a/src/components/common/Heatmap.tsx
+++ b/src/components/common/Heatmap.tsx
@@ -6,6 +6,7 @@ import HeatMap from "react-heatmap-grid";
 import HeatmapTooltip from "./HeatmapTooltip";
 import { HierarchicalItem, ISubConnections } from "./Types.ts";
 import { getNormalizedValueForMinMax } from "../../services/summaryHeatmapService.ts";
+import { getPhenotypeColors } from "../../services/heatmapService.ts";
 
 
 const { gray50, primaryPurple500, gray100A, gray500 } = vars;
@@ -82,15 +83,7 @@ const HeatmapGrid: FC<HeatmapGridProps> = ({
     ) => {
         if (secondary && secondaryHeatmapData && secondaryHeatmapData[_y] && secondaryHeatmapData[_y][_x]) {
             const phenotypeColors = secondaryHeatmapData[_y][_x]?.color;
-
-            const phenotypeColorsWithPercentage = phenotypeColors.map((color, index) => {
-                return `${color} ${100 / phenotypeColors.length * index}%, ${color} ${100 / phenotypeColors.length * (index + 1)}%`
-            })
-            let phenotypeColor = phenotypeColors.length > 1 ? `linear-gradient(to right, ${phenotypeColorsWithPercentage.join(',')}` :
-                phenotypeColors.length === 1 ? phenotypeColors[0] : '';
-            phenotypeColor = phenotypeColor?.replace(/rgba\(([^,]+),([^,]+),([^,]+),([^)]+)\)/g, `rgba($1,$2,$3,${normalizedValue})`).replace(
-                /rgb\(([^,]+),([^,]+),([^,]+)\)/g, `rgba($1,$2,$3,${normalizedValue})`
-            );
+            const phenotypeColor = getPhenotypeColors(normalizedValue, phenotypeColors);
 
             return phenotypeColor ? phenotypeColor : `rgba(131, 0, 191, ${normalizedValue})`;
         }

--- a/src/components/common/HeatmapTooltip.tsx
+++ b/src/components/common/HeatmapTooltip.tsx
@@ -40,7 +40,7 @@ const HeatmapTooltip: FC<HeatmapTooltipProps> = ({value, x, y, secondary, getCel
               <Box sx={{
                 width: '1.4794rem', 
                 height: '1rem', 
-                background: getCellBgColor(value)       
+                background: getCellBgColor(value)
               }} 
               />
               <Typography sx={commonTextStyles}>

--- a/src/components/common/Loader.tsx
+++ b/src/components/common/Loader.tsx
@@ -1,0 +1,12 @@
+import { Box, CircularProgress } from "@mui/material";
+import React from 'react'
+
+const Loader = () => {
+	return (
+		<Box display="flex" justifyContent="center" alignItems="center" height="100vh" width="100vw">
+			<CircularProgress />
+		</Box>
+	)
+}
+
+export default Loader

--- a/src/components/common/Types.ts
+++ b/src/components/common/Types.ts
@@ -12,7 +12,8 @@ export type Option = {
 }
 
 export type ksMapType = Record<string, { ks: KnowledgeStatement, count: number }>;
-export interface ISubConnections { count: number, color: string[] };
+export type ISubConnections = { count: number, color: string[], ksIds: Set<string> };
+export type SummaryType = 'summary' | 'detailedSummary' | 'instruction';
 
 export type DetailedHeatmapData = { label: string, data: Set<string>[], id: string }[];
 
@@ -20,3 +21,14 @@ export interface IHeatmapMatrixInformation {
   heatmapMatrix: number[][];
   detailedHeatmap: DetailedHeatmapData;
 }
+export interface HierarchicalItem {
+  id: string;
+  label: string;
+  children: HierarchicalItem[];
+  expanded: boolean;
+}
+
+export type PhenotypeDetail = {
+  label: string;
+  color: string;
+};

--- a/src/components/common/Types.ts
+++ b/src/components/common/Types.ts
@@ -14,7 +14,12 @@ export type Option = {
 export type LabelIdPair = { labels: string[], ids: string[] };
 
 export type KsMapType = Record<string, KnowledgeStatement>;
-export type SubConnections = { phenotypes: string[], ksIds: Set<string> };
+
+export type PhenotypeKsIdMap = { phenotypes: string[], ksIds: Set<string> };
+
+// SummaryType - Three types of summary views - default - instruction. 
+// When user clicks the primary heatmap, the summary view will be displayed.
+// When user clicks the secondary heatmap, the detailed summary view will be displayed.
 export enum SummaryType {
   Summary = 'summary',
   DetailedSummary = 'detailedSummary',
@@ -23,7 +28,7 @@ export enum SummaryType {
 
 export type DetailedHeatmapData = { label: string, data: Set<string>[], id: string }[];
 
-export interface IHeatmapMatrixInformation {
+export interface HeatmapMatrixInformation {
   heatmapMatrix: number[][];
   detailedHeatmap: DetailedHeatmapData;
 }

--- a/src/components/common/Types.ts
+++ b/src/components/common/Types.ts
@@ -1,3 +1,5 @@
+import { KnowledgeStatement } from "../../models/explorer";
+
 export type OptionDetail = {
   title: string; // What to display as the title/label for the property.
   value: string; // The actual value/content for the property.
@@ -7,4 +9,14 @@ export type Option = {
   label: string;
   group: string;
   content: OptionDetail[];
+}
+
+export type ksMapType = Record<string, { ks: KnowledgeStatement, count: number }>;
+export interface ISubConnections { count: number, color: string[] };
+
+export type DetailedHeatmapData = { label: string, data: Set<string>[], id: string }[];
+
+export interface IHeatmapMatrixInformation {
+  heatmapMatrix: number[][];
+  detailedHeatmap: DetailedHeatmapData;
 }

--- a/src/components/common/Types.ts
+++ b/src/components/common/Types.ts
@@ -12,7 +12,7 @@ export type Option = {
 }
 
 export type KsMapType = Record<string, { ks: KnowledgeStatement, count: number }>;
-export type ISubConnections = { count: number, color: string[], ksIds: Set<string> };
+export type SubConnections = { count: number, colors: string[], ksIds: Set<string> };
 export enum SummaryType {
   Summary = 'summary',
   DetailedSummary = 'detailedSummary',

--- a/src/components/common/Types.ts
+++ b/src/components/common/Types.ts
@@ -11,7 +11,8 @@ export type Option = {
   content: OptionDetail[];
 }
 
-export type KsMapType = Record<string, { ks: KnowledgeStatement, count: number }>;
+
+export type KsMapType = Record<string, KnowledgeStatement>;
 export type SubConnections = { count: number, colors: string[], ksIds: Set<string> };
 export enum SummaryType {
   Summary = 'summary',

--- a/src/components/common/Types.ts
+++ b/src/components/common/Types.ts
@@ -14,7 +14,7 @@ export type Option = {
 export type LabelIdPair = { labels: string[], ids: string[] };
 
 export type KsMapType = Record<string, KnowledgeStatement>;
-export type SubConnections = { colors: string[], ksIds: Set<string> };
+export type SubConnections = { phenotypes: string[], ksIds: Set<string> };
 export enum SummaryType {
   Summary = 'summary',
   DetailedSummary = 'detailedSummary',
@@ -37,5 +37,8 @@ export interface HierarchicalItem {
 export type PhenotypeDetail = {
   label: string;
   color: string;
-  ksId: string;
 };
+
+export type PhenotypeType = {
+  [key: string]: PhenotypeDetail;
+}

--- a/src/components/common/Types.ts
+++ b/src/components/common/Types.ts
@@ -11,9 +11,13 @@ export type Option = {
   content: OptionDetail[];
 }
 
-export type ksMapType = Record<string, { ks: KnowledgeStatement, count: number }>;
+export type KsMapType = Record<string, { ks: KnowledgeStatement, count: number }>;
 export type ISubConnections = { count: number, color: string[], ksIds: Set<string> };
-export type SummaryType = 'summary' | 'detailedSummary' | 'instruction';
+export enum SummaryType {
+  Summary = 'summary',
+  DetailedSummary = 'detailedSummary',
+  Instruction = 'instruction'
+}
 
 export type DetailedHeatmapData = { label: string, data: Set<string>[], id: string }[];
 

--- a/src/components/common/Types.ts
+++ b/src/components/common/Types.ts
@@ -11,9 +11,10 @@ export type Option = {
   content: OptionDetail[];
 }
 
+export type LabelIdPair = { labels: string[], ids: string[] };
 
 export type KsMapType = Record<string, KnowledgeStatement>;
-export type SubConnections = { count: number, colors: string[], ksIds: Set<string> };
+export type SubConnections = { colors: string[], ksIds: Set<string> };
 export enum SummaryType {
   Summary = 'summary',
   DetailedSummary = 'detailedSummary',
@@ -36,4 +37,5 @@ export interface HierarchicalItem {
 export type PhenotypeDetail = {
   label: string;
   color: string;
+  ksId: string;
 };

--- a/src/components/connections/ConnectionsTableView.tsx
+++ b/src/components/connections/ConnectionsTableView.tsx
@@ -8,23 +8,16 @@ import Paper from '@mui/material/Paper';
 import {vars} from "../../theme/variables.ts";
 
 const { gray50, gray25} = vars
-function createData(
-  Origin: string,
-  Destination: string,
-  Via: string,
-) {
-  return { Origin, Destination, Via };
+
+export interface Row {
+  Origin: string;
+  Destination: string;
+  Via: string;
 }
 
-const rows = [
-  createData('Third thoracic dorsal root ganglion', 'Heart right ventricle', 'White matter of spinal cord'),
-  createData('Third thoracic dorsal root ganglion', 'Heart right ventricle', 'White matter of spinal cord'),
-  createData('Third thoracic dorsal root ganglion', 'Heart right ventricle', 'White matter of spinal cord'),
-  createData('Third thoracic dorsal root ganglion', 'Heart right ventricle', 'White matter of spinal cord'),
-  createData('Third thoracic dorsal root ganglion', 'Heart right ventricle', 'White matter of spinal cord'),
-];
-
-export default function ConnectionsTableView() {
+export default function ConnectionsTableView(
+  { tableData }: { tableData: Row[] }
+) {
   return (
     <TableContainer component={Paper}>
       <Table aria-label="customized table">
@@ -44,7 +37,7 @@ export default function ConnectionsTableView() {
           </TableRow>
         </TableHead>
         <TableBody>
-          {rows.map((row) => (
+          {tableData.map((row) => (
             <TableRow key={row.Origin} sx={{
               '&:nth-of-type(even)': {
                 backgroundColor: gray25,

--- a/src/components/connections/Details.tsx
+++ b/src/components/connections/Details.tsx
@@ -11,7 +11,7 @@ import PopulationDisplay from "./PopulationDisplay.tsx";
 import CommonAccordion from "../common/Accordion.tsx";
 import CommonChip from "../common/CommonChip.tsx";
 import { ArrowOutward } from "../icons";
-import { ksMapType } from '../common/Types.ts';
+import { KsMapType } from '../common/Types.ts';
 import { KnowledgeStatement } from '../../models/explorer.ts';
 
 const { gray500, gray700, gray800} = vars;
@@ -39,13 +39,13 @@ const RowStack = ({ label, value, Icon }: {label: string, value: string, Icon?: 
 
 const Details = ({
   uniqueKS,
-  connectionCount
+  connectionPage
 }: {
-  uniqueKS: ksMapType,
-  connectionCount: number
+    uniqueKS: KsMapType,
+    connectionPage: number
 }) => {
   const connectionDetails = uniqueKS !== undefined ?
-    uniqueKS[Object.keys(uniqueKS)[connectionCount - 1]]?.ks
+    uniqueKS[Object.keys(uniqueKS)[connectionPage - 1]]?.ks
     : {} as KnowledgeStatement;
   const phenotype = connectionDetails?.phenotype || ''
   const detailsObject = [

--- a/src/components/connections/Details.tsx
+++ b/src/components/connections/Details.tsx
@@ -10,7 +10,7 @@ import { vars } from "../../theme/variables.ts";
 import PopulationDisplay from "./PopulationDisplay.tsx";
 import CommonAccordion from "../common/Accordion.tsx";
 import CommonChip from "../common/CommonChip.tsx";
-import { ArrowOutward, HelpCircle } from "../icons";
+import { ArrowOutward } from "../icons";
 import { ksMapType } from '../common/Types.ts';
 import { KnowledgeStatement } from '../../models/explorer.ts';
 

--- a/src/components/connections/Details.tsx
+++ b/src/components/connections/Details.tsx
@@ -11,6 +11,8 @@ import PopulationDisplay from "./PopulationDisplay.tsx";
 import CommonAccordion from "../common/Accordion.tsx";
 import CommonChip from "../common/CommonChip.tsx";
 import { ArrowOutward, HelpCircle } from "../icons";
+import { ksMapType } from '../common/Types.ts';
+import { KnowledgeStatement } from '../../models/explorer.ts';
 
 const { gray500, gray700, gray800} = vars;
 
@@ -35,30 +37,50 @@ const RowStack = ({ label, value, Icon }: {label: string, value: string, Icon?: 
   </Stack>
 );
 
-const Details = () => {
-  const detailsObject = {
-    knowledge_statement: 'Fifth thoracic dorsal root ganglion to Heart right ventricle via White matter of spinal cord',
-    type: 'Sympathetic',
-    connectionDetails: [
-      {
-        label: 'Status',
-        value: 'Inferred',
-        icon: HelpCircle
-      },
-      {
-        label: 'Species',
-        value: 'Mammal',
-      },
-      {
-        label: 'Label',
-        value: 'Neuron type aacar 13',
-      },
-      {
-        label: 'Provenances',
-        value: ['www.microsoft.com', 'google.com'],
-      },
-    ]
-  }
+const Details = ({
+  uniqueKS,
+  connectionCount
+}: {
+  uniqueKS: ksMapType,
+  connectionCount: number
+}) => {
+  const connectionDetails = uniqueKS !== undefined ?
+    uniqueKS[Object.keys(uniqueKS)[connectionCount - 1]]?.ks
+    : {} as KnowledgeStatement;
+  const phenotype = connectionDetails?.phenotype || ''
+  const detailsObject = [
+    {
+      label: 'Laterality',
+      value: connectionDetails?.laterality || '-',
+      icon: undefined
+    },
+    {
+      label: 'Projection',
+      value: connectionDetails?.projection || '-',
+      icon: undefined
+    },
+    {
+      label: 'Circuit Type',
+      value: connectionDetails?.circuit_type || '-',
+      icon: undefined
+    },
+    {
+      label: 'Provenances',
+      value: connectionDetails?.provenances || [],
+      icon: undefined
+    }, 
+    {
+      label: 'PhenoType',
+      value: connectionDetails?.phenotype || '-',
+      icon: undefined
+    },
+    {
+      label: 'Sex',
+      value: connectionDetails?.sex.name || '-',
+      icon: undefined
+    }
+  ]
+
   return (
     <Stack spacing='1.5rem'>
       <Box pl='1.5rem' pr='1.5rem'>
@@ -80,16 +102,16 @@ const Details = () => {
             Knowledge statement
           </Typography>
           <Typography variant='body1' color={gray500}>
-            {detailsObject.knowledge_statement}
+            {connectionDetails?.statement_preview || connectionDetails?.knowledge_statement || '-'}
           </Typography>
-          <CommonChip label={detailsObject.type} variant="outlined" />
+          {phenotype && <CommonChip label={phenotype} variant="outlined" />}
           <CommonAccordion
             summary="Connection Details"
             details={
               <>
                 <Stack spacing={1}>
                   {
-                    detailsObject.connectionDetails.map((row) =>
+                    detailsObject.map((row) =>
                       !Array.isArray(row.value) ?
                         <RowStack label={row.label} value={row.value} Icon={row.icon} /> :
                         <Stack
@@ -101,11 +123,12 @@ const Details = () => {
                           <Stack
                             direction="row"
                             alignItems="center"
+                            flexWrap={'wrap'}
                             spacing={'.5rem'}
                           >
                             {
-                              row.value.map((row) =>
-                                <CommonChip label={row} variant="outlined" className='link' icon={<ArrowOutwardRoundedIcon fontSize='small' />} />
+                              row.value.map((row, index) =>
+                                <CommonChip key={index} label={row} variant="outlined" className='link' icon={<ArrowOutwardRoundedIcon fontSize='small' />} />
                               )
                             }
                           </Stack>
@@ -120,7 +143,9 @@ const Details = () => {
       </Box>
    
       <Divider />
-      <PopulationDisplay />
+      <PopulationDisplay
+        connectionDetails={connectionDetails}
+      />
     </Stack>
   );
 };

--- a/src/components/connections/PhenotypeLegend.tsx
+++ b/src/components/connections/PhenotypeLegend.tsx
@@ -1,13 +1,14 @@
 import { Box, Typography } from "@mui/material"
-import { PhenotypeDetail } from "../common/Types"
+import { PhenotypeDetail, PhenotypeType } from "../common/Types"
 import { vars } from "../../theme/variables";
 
 const { gray100 } = vars;
 
 
 const PhenotypeLegend = (
-	{ phenotypes }: { phenotypes: PhenotypeDetail[] }
+	{ phenotypes }: { phenotypes: PhenotypeType }
 ) => {
+	const phenotypesLegends = Object.values(phenotypes);
 	return (
 		<Box sx={{
 			position: 'sticky',
@@ -34,7 +35,7 @@ const PhenotypeLegend = (
 					alignItems: 'center',
 					gap: '1.5rem'
 				}}>
-					{phenotypes?.map((phenotype: PhenotypeDetail) => (
+					{phenotypesLegends?.map((phenotype: PhenotypeDetail) => (
 						<Box sx={{
 							p: '0.1875rem 0.25rem',
 							display: 'flex',

--- a/src/components/connections/PhenotypeLegend.tsx
+++ b/src/components/connections/PhenotypeLegend.tsx
@@ -1,0 +1,67 @@
+import { Box, Typography } from "@mui/material"
+import { PhenotypeDetail } from "../common/Types"
+import { vars } from "../../theme/variables";
+
+const { gray100 } = vars;
+
+
+const PhenotypeLegend = (
+	{ phenotypes }: { phenotypes: PhenotypeDetail[] }
+) => {
+	return (
+		<Box sx={{
+			position: 'sticky',
+			bottom: 0,
+			padding: '0 1.5rem',
+			background: '#fff'
+		}}>
+			<Box sx={{
+				borderTop: `0.0625rem solid ${gray100}`,
+				padding: '0.9375rem 0',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'space-between'
+			}}>
+				<Typography sx={{
+					fontSize: '0.75rem',
+					fontWeight: 500,
+					lineHeight: '1.125rem',
+					color: '#818898'
+				}}>Phenotype</Typography>
+
+				<Box sx={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: '1.5rem'
+				}}>
+					{phenotypes?.map((type: PhenotypeDetail) => (
+						<Box sx={{
+							p: '0.1875rem 0.25rem',
+							display: 'flex',
+							alignItems: 'center',
+							gap: '0.375rem'
+						}}
+							key={type.label}
+						>
+							<Box sx={{
+								width: '1.4794rem',
+								height: '1rem',
+								borderRadius: '0.125rem',
+								background: `${type.color}`
+							}} />
+							<Typography sx={{
+								fontSize: '0.75rem',
+								fontWeight: 400,
+								lineHeight: '1.125rem',
+								color: '#4A4C4F'
+							}}>{type.label}</Typography>
+						</Box>
+					))}
+				</Box>
+			</Box>
+		</Box>
+	)
+
+}
+
+export default PhenotypeLegend

--- a/src/components/connections/PhenotypeLegend.tsx
+++ b/src/components/connections/PhenotypeLegend.tsx
@@ -34,27 +34,27 @@ const PhenotypeLegend = (
 					alignItems: 'center',
 					gap: '1.5rem'
 				}}>
-					{phenotypes?.map((type: PhenotypeDetail) => (
+					{phenotypes?.map((phenotype: PhenotypeDetail) => (
 						<Box sx={{
 							p: '0.1875rem 0.25rem',
 							display: 'flex',
 							alignItems: 'center',
 							gap: '0.375rem'
 						}}
-							key={type.label}
+							key={phenotype.label}
 						>
 							<Box sx={{
 								width: '1.4794rem',
 								height: '1rem',
 								borderRadius: '0.125rem',
-								background: `${type.color}`
+								background: `${phenotype.color}`
 							}} />
 							<Typography sx={{
 								fontSize: '0.75rem',
 								fontWeight: 400,
 								lineHeight: '1.125rem',
 								color: '#4A4C4F'
-							}}>{type.label}</Typography>
+							}}>{phenotype.label}</Typography>
 						</Box>
 					))}
 				</Box>

--- a/src/components/connections/PopulationDisplay.tsx
+++ b/src/components/connections/PopulationDisplay.tsx
@@ -50,7 +50,7 @@ const PopulationDisplay = ({
 }) => {
   const [value, setValue] = React.useState(0);
   
-  const viaDetails: ViaExplorerSerializerDetails[] = connectionDetails?.via || [];
+  const viaDetails: ViaExplorerSerializerDetails[] = connectionDetails?.vias || [];
   const destinationDetails: DestinationExplorerSerializerDetails[] = connectionDetails?.destinations || [];
   const origins = connectionDetails?.origins || [];
 

--- a/src/components/connections/PopulationDisplay.tsx
+++ b/src/components/connections/PopulationDisplay.tsx
@@ -59,9 +59,9 @@ const PopulationDisplay = ({
     const origins = connectionDetails?.origins || [];
     const destinations = destinationDetails.flatMap(dest => dest.anatomical_entities);
     const vias = viaDetails.flatMap(via => via.anatomical_entities);
-    origins.forEach((origin, index) => {
-      destinations.forEach((destination, index) => {
-        vias.forEach((via, index) => {
+    origins.forEach((origin) => {
+      destinations.forEach((destination) => {
+        vias.forEach((via) => {
           rowData.push({
             Origin: origin.name,
             Destination: destination.name,

--- a/src/components/connections/PopulationDisplay.tsx
+++ b/src/components/connections/PopulationDisplay.tsx
@@ -6,9 +6,9 @@ import {
   Tabs, Tab
 } from "@mui/material";
 import { vars } from "../../theme/variables.ts";
-import ConnectionsTableView from "./ConnectionsTableView.tsx";
+import ConnectionsTableView, { Row } from "./ConnectionsTableView.tsx";
 import GraphDiagram from "../graphDiagram/GraphDiagram.tsx";
-import {MOCKED_composerStatement} from "../../resources/mockedData/MOCKED_composerStatement.ts";
+import { DestinationExplorerSerializerDetails, KnowledgeStatement, ViaExplorerSerializerDetails } from '../../models/explorer.ts';
 
 const { gray700} = vars
 
@@ -43,10 +43,38 @@ function CustomTabPanel(props: TabPanelProps) {
     </Box>
   );
 }
-const PopulationDisplay = () => {
+const PopulationDisplay = ({
+  connectionDetails
+}: {
+  connectionDetails: KnowledgeStatement
+}) => {
   const [value, setValue] = React.useState(0);
   
-  
+  const viaDetails: ViaExplorerSerializerDetails[] = connectionDetails?.via || [];
+  const destinationDetails: DestinationExplorerSerializerDetails[] = connectionDetails?.destinations || [];
+  const origins = connectionDetails?.origins || [];
+
+  const getTabularData = (connectionDetails: KnowledgeStatement): Row[] => {
+    const rowData: Row[] = [];
+    const origins = connectionDetails?.origins || [];
+    const destinations = destinationDetails.flatMap(dest => dest.anatomical_entities);
+    const vias = viaDetails.flatMap(via => via.anatomical_entities);
+    origins.forEach((origin, index) => {
+      destinations.forEach((destination, index) => {
+        vias.forEach((via, index) => {
+          rowData.push({
+            Origin: origin.name,
+            Destination: destination.name,
+            Via: via.name
+          });
+        })
+      })
+    })
+    return rowData;
+  }
+
+  const tableData = getTabularData(connectionDetails);
+
   // @ts-expect-error Explanation: Handling Event properly
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
@@ -65,12 +93,12 @@ const PopulationDisplay = () => {
       </Stack>
       <CustomTabPanel value={value} index={0}>
         <Box sx={{height: '50rem', width: '100%', background: '#EDEFF2'}}>
-          <GraphDiagram origins={MOCKED_composerStatement.origins} vias={MOCKED_composerStatement.vias}
-                        destinations={MOCKED_composerStatement.destinations}/>
+          <GraphDiagram origins={origins} vias={viaDetails}
+            destinations={destinationDetails} />
         </Box>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
-        <ConnectionsTableView />
+        <ConnectionsTableView tableData={tableData} />
       </CustomTabPanel>
     </Stack>
   );

--- a/src/components/connections/SummaryDetails.tsx
+++ b/src/components/connections/SummaryDetails.tsx
@@ -12,7 +12,7 @@ import CommonAccordion from "../common/Accordion.tsx";
 import CommonChip from "../common/CommonChip.tsx";
 import { ArrowOutward } from "../icons/index.tsx";
 import { KsMapType } from '../common/Types.ts';
-import { KnowledgeStatement } from '../../models/explorer.ts';
+import { getConnectionDetails } from '../../services/summaryHeatmapService.ts';
 
 const { gray500, gray700, gray800 } = vars;
 
@@ -37,17 +37,20 @@ const RowStack = ({ label, value, Icon }: { label: string, value: string, Icon?:
   </Stack>
 );
 
+
+type SummaryDetailsProps = {
+  uniqueKS: KsMapType,
+  connectionPage: number
+}
+
 const SummaryDetails = ({
   uniqueKS,
   connectionPage
-}: {
-  uniqueKS: KsMapType,
-  connectionPage: number
-}) => {
-  const connectionDetails = uniqueKS !== undefined ?
-    uniqueKS[Object.keys(uniqueKS)[connectionPage - 1]]
-    : {} as KnowledgeStatement;
+}: SummaryDetailsProps) => {
+  const connectionDetails = getConnectionDetails(uniqueKS, connectionPage);
   const phenotype = connectionDetails?.phenotype || ''
+
+  // Details shown in the dropdown - from composer
   const detailsObject = [
     {
       label: 'Laterality',

--- a/src/components/connections/SummaryDetails.tsx
+++ b/src/components/connections/SummaryDetails.tsx
@@ -10,13 +10,13 @@ import { vars } from "../../theme/variables.ts";
 import PopulationDisplay from "./PopulationDisplay.tsx";
 import CommonAccordion from "../common/Accordion.tsx";
 import CommonChip from "../common/CommonChip.tsx";
-import { ArrowOutward } from "../icons";
+import { ArrowOutward } from "../icons/index.tsx";
 import { KsMapType } from '../common/Types.ts';
 import { KnowledgeStatement } from '../../models/explorer.ts';
 
-const { gray500, gray700, gray800} = vars;
+const { gray500, gray700, gray800 } = vars;
 
-const RowStack = ({ label, value, Icon }: {label: string, value: string, Icon?: React.ElementType}) => (
+const RowStack = ({ label, value, Icon }: { label: string, value: string, Icon?: React.ElementType }) => (
   <Stack
     direction="row"
     alignItems="center"
@@ -37,15 +37,15 @@ const RowStack = ({ label, value, Icon }: {label: string, value: string, Icon?: 
   </Stack>
 );
 
-const Details = ({
+const SummaryDetails = ({
   uniqueKS,
   connectionPage
 }: {
-    uniqueKS: KsMapType,
-    connectionPage: number
+  uniqueKS: KsMapType,
+  connectionPage: number
 }) => {
   const connectionDetails = uniqueKS !== undefined ?
-    uniqueKS[Object.keys(uniqueKS)[connectionPage - 1]]?.ks
+    uniqueKS[Object.keys(uniqueKS)[connectionPage - 1]]
     : {} as KnowledgeStatement;
   const phenotype = connectionDetails?.phenotype || ''
   const detailsObject = [
@@ -68,7 +68,7 @@ const Details = ({
       label: 'Provenances',
       value: connectionDetails?.provenances || [],
       icon: undefined
-    }, 
+    },
     {
       label: 'PhenoType',
       value: connectionDetails?.phenotype || '-',
@@ -141,7 +141,7 @@ const Details = ({
           />
         </Stack>
       </Box>
-   
+
       <Divider />
       <PopulationDisplay
         connectionDetails={connectionDetails}
@@ -150,4 +150,4 @@ const Details = ({
   );
 };
 
-export default Details;
+export default SummaryDetails;

--- a/src/components/connections/SummaryHeader.tsx
+++ b/src/components/connections/SummaryHeader.tsx
@@ -5,7 +5,7 @@ import { ArrowDown, ArrowRight, ArrowUp, HelpCircle } from "../icons";
 import Breadcrumbs from "@mui/material/Breadcrumbs";
 import { SummaryType, ksMapType } from '../common/Types';
 
-const { gray100, primaryPurple600, gray600A, gray500 } = vars;
+const { gray100, gray600A, gray500 } = vars;
 
 const SummaryHeader = ({
    showDetails,

--- a/src/components/connections/SummaryHeader.tsx
+++ b/src/components/connections/SummaryHeader.tsx
@@ -3,7 +3,7 @@ import { vars } from "../../theme/variables";
 import IconButton from "@mui/material/IconButton";
 import { ArrowDown, ArrowRight, ArrowUp, HelpCircle } from "../icons";
 import Breadcrumbs from "@mui/material/Breadcrumbs";
-import { SummaryType, ksMapType } from '../common/Types';
+import { SummaryType, KsMapType } from '../common/Types';
 
 const { gray100, gray600A, gray500 } = vars;
 
@@ -11,33 +11,33 @@ const SummaryHeader = ({
    showDetails,
    setShowDetails,
   uniqueKS,
-  connectionCount,
-  setConnectionCount,
+  connectionPage,
+  setConnectionPage,
   totalConnectionCount
 }: {
     showDetails: SummaryType,
     setShowDetails: (showDetails: SummaryType) => void,
-    uniqueKS: ksMapType,
-    connectionCount: number,
-    setConnectionCount: (connectionCount: number) => void,
+    uniqueKS: KsMapType,
+    connectionPage: number,
+    setConnectionPage: (connectionPage: number) => void,
     totalConnectionCount: number
 }) => {
   const totalUniqueKS = Object.keys(uniqueKS).length;
 
   function getConnectionId() {
-    return Object.keys(uniqueKS)[connectionCount - 1] || ''
+    return Object.keys(uniqueKS)[connectionPage - 1] || ''
   }
   const connectionId = getConnectionId()
 
   const handleUpClick = () => {
-    if (connectionCount < totalUniqueKS) {
-      setConnectionCount(connectionCount + 1);
+    if (connectionPage < totalUniqueKS) {
+      setConnectionPage(connectionPage + 1);
     }
   };
   
   const handleDownClick = () => {
-    if (connectionCount > 1) {
-      setConnectionCount(connectionCount - 1);
+    if (connectionPage > 1) {
+      setConnectionPage(connectionPage - 1);
     }
   };
   
@@ -62,7 +62,7 @@ const SummaryHeader = ({
         alignItems='center'
         spacing='1rem'
       >
-        {showDetails === 'detailedSummary' && <ButtonGroup variant="outlined" sx={{
+        {showDetails === SummaryType.DetailedSummary && <ButtonGroup variant="outlined" sx={{
           '& .MuiButtonBase-root': {
             width: '2rem',
             height: '2rem'
@@ -84,18 +84,18 @@ const SummaryHeader = ({
           separator={<ArrowRight />}
           aria-label="breadcrumb"
         >
-          {showDetails === 'detailedSummary' ? (
-            <Link underline="hover" onClick={() => setShowDetails('summary')}>
+          {showDetails === SummaryType.DetailedSummary ? (
+            <Link underline="hover" onClick={() => setShowDetails(SummaryType.Summary)}>
               Summary
             </Link>
-          ) : showDetails === 'summary' ? (
+          ) : showDetails === SummaryType.Summary ? (
             <Typography>
               Summary
             </Typography>
             ) : <></>
           }
           {
-            showDetails === 'detailedSummary' &&
+            showDetails === SummaryType.DetailedSummary &&
               <Typography>
                 {connectionId}
               </Typography>
@@ -109,14 +109,14 @@ const SummaryHeader = ({
         gap: '0.75rem'
       }}>
         {
-          showDetails === 'detailedSummary' ? (
+          showDetails === SummaryType.DetailedSummary ? (
             <>
               <Typography variant='subtitle1' color={gray500}>
-                Displaying connection {connectionCount} of {totalUniqueKS}
+                Displaying connection {connectionPage} of {totalUniqueKS}
               </Typography>
               <HelpCircle />
             </>
-          ) : showDetails === 'summary' ? (
+          ) : showDetails === SummaryType.Summary ? (
             <>
                 <Box sx={{
                   display: 'flex',

--- a/src/components/connections/SummaryHeader.tsx
+++ b/src/components/connections/SummaryHeader.tsx
@@ -7,6 +7,17 @@ import { SummaryType, KsMapType } from '../common/Types';
 
 const { gray100, gray600A, gray500 } = vars;
 
+
+type SummaryHeaderProps = {
+  showDetails: SummaryType,
+  setShowDetails: (showDetails: SummaryType) => void,
+  uniqueKS: KsMapType,
+  connectionPage: number,
+  setConnectionPage: (connectionPage: number) => void,
+  totalConnectionCount: number
+}
+
+
 const SummaryHeader = ({
    showDetails,
    setShowDetails,
@@ -14,14 +25,7 @@ const SummaryHeader = ({
   connectionPage,
   setConnectionPage,
   totalConnectionCount
-}: {
-    showDetails: SummaryType,
-    setShowDetails: (showDetails: SummaryType) => void,
-    uniqueKS: KsMapType,
-    connectionPage: number,
-    setConnectionPage: (connectionPage: number) => void,
-    totalConnectionCount: number
-}) => {
+}: SummaryHeaderProps) => {
   const totalUniqueKS = Object.keys(uniqueKS).length;
 
   function getConnectionId() {

--- a/src/components/connections/SummaryHeader.tsx
+++ b/src/components/connections/SummaryHeader.tsx
@@ -1,34 +1,43 @@
-import { useState } from 'react';
 import { Box, Button, ButtonGroup, Divider, Typography, Stack, Link } from "@mui/material";
 import { vars } from "../../theme/variables";
 import IconButton from "@mui/material/IconButton";
 import { ArrowDown, ArrowRight, ArrowUp, HelpCircle } from "../icons";
 import Breadcrumbs from "@mui/material/Breadcrumbs";
+import { SummaryType, ksMapType } from '../common/Types';
 
 const { gray100, primaryPurple600, gray600A, gray500 } = vars;
 
 const SummaryHeader = ({
    showDetails,
    setShowDetails,
-   numOfConnections,
-   connection
-  }: {
-  showDetails: boolean,
-  setShowDetails: (showDetails: boolean) => void,
-  numOfConnections: number,
-  connection: string
+  uniqueKS,
+  connectionCount,
+  setConnectionCount,
+  totalConnectionCount
+}: {
+    showDetails: SummaryType,
+    setShowDetails: (showDetails: SummaryType) => void,
+    uniqueKS: ksMapType,
+    connectionCount: number,
+    setConnectionCount: (connectionCount: number) => void,
+    totalConnectionCount: number
 }) => {
-  const [connectionCount, setConnectionCount] = useState(1);
-  
+  const totalUniqueKS = Object.keys(uniqueKS).length;
+
+  function getConnectionId() {
+    return Object.keys(uniqueKS)[connectionCount - 1] || ''
+  }
+  const connectionId = getConnectionId()
+
   const handleUpClick = () => {
-    if (connectionCount < numOfConnections) {
-      setConnectionCount(prevCount => prevCount + 1);
+    if (connectionCount < totalUniqueKS) {
+      setConnectionCount(connectionCount + 1);
     }
   };
   
   const handleDownClick = () => {
     if (connectionCount > 1) {
-      setConnectionCount(prevCount => prevCount - 1);
+      setConnectionCount(connectionCount - 1);
     }
   };
   
@@ -53,18 +62,21 @@ const SummaryHeader = ({
         alignItems='center'
         spacing='1rem'
       >
-        {showDetails && <ButtonGroup variant="outlined" sx={{
+        {showDetails === 'detailedSummary' && <ButtonGroup variant="outlined" sx={{
           '& .MuiButtonBase-root': {
             width: '2rem',
             height: '2rem'
           }
         }}>
-            <IconButton onClick={handleUpClick}>
-                <ArrowUp />
-            </IconButton>
-            <IconButton sx={{ marginLeft: '.25rem' }} onClick={handleDownClick}>
-                <ArrowDown />
-            </IconButton>
+          <IconButton
+            onClick={handleUpClick}>
+            <ArrowUp />
+          </IconButton>
+          <IconButton sx={{
+            marginLeft: '.25rem',
+          }} onClick={handleDownClick}>
+            <ArrowDown />
+          </IconButton>
         </ButtonGroup>
         }
         
@@ -72,18 +84,20 @@ const SummaryHeader = ({
           separator={<ArrowRight />}
           aria-label="breadcrumb"
         >
-          {showDetails ?
-            <Link underline="hover" onClick={() => setShowDetails(false)}>
+          {showDetails === 'detailedSummary' ? (
+            <Link underline="hover" onClick={() => setShowDetails('summary')}>
               Summary
-            </Link> :
+            </Link>
+          ) : showDetails === 'summary' ? (
             <Typography>
               Summary
             </Typography>
+            ) : <></>
           }
           {
-            showDetails &&
+            showDetails === 'detailedSummary' &&
               <Typography>
-                {connection}
+                {connectionId}
               </Typography>
           }
         </Breadcrumbs>
@@ -95,43 +109,38 @@ const SummaryHeader = ({
         gap: '0.75rem'
       }}>
         {
-          showDetails ?
+          showDetails === 'detailedSummary' ? (
             <>
               <Typography variant='subtitle1' color={gray500}>
-                Displaying connection {connectionCount} of {numOfConnections}
+                Displaying connection {connectionCount} of {totalUniqueKS}
               </Typography>
               <HelpCircle />
-            </> :
-            <>
-          <Typography sx={{
-              fontSize: '0.875rem',
-              fontWeight: 500,
-              lineHeight: '1.25rem',
-              color: primaryPurple600
-          }}>Summary</Typography>
-
-          <Box sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.75rem'
-          }}>
-              <Typography sx={{
-                fontSize: '0.875rem',
-                fontWeight: 500,
-                lineHeight: '1.25rem',
-                color: gray600A
-                
-              }}>{numOfConnections} connections</Typography>
-              
-              <Divider sx={{
-                height: '2.25rem',
-                width: '0.0625rem',
-                background: gray100
-              }} />
-              
-              <Button variant="contained">Download results (.csv)</Button>
-              </Box>
             </>
+          ) : showDetails === 'summary' ? (
+            <>
+                <Box sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.75rem'
+                }}>
+                  <Typography sx={{
+                    fontSize: '0.875rem',
+                    fontWeight: 500,
+                    lineHeight: '1.25rem',
+                    color: gray600A
+
+                  }}>{totalConnectionCount} connections</Typography>
+
+                  <Divider sx={{
+                    height: '2.25rem',
+                    width: '0.0625rem',
+                    background: gray100
+                  }} />
+
+                  <Button variant="contained">Download results (.csv)</Button>
+                </Box>
+              </>
+            ) : <></>
         }
       </Box>
     </Stack>

--- a/src/components/connections/SummaryHeader.tsx
+++ b/src/components/connections/SummaryHeader.tsx
@@ -40,7 +40,11 @@ const SummaryHeader = ({
       setConnectionPage(connectionPage - 1);
     }
   };
-  
+
+  if (showDetails === SummaryType.Instruction) {
+    return <></>
+  }
+
   return (
     <Stack
       direction='row'
@@ -88,11 +92,11 @@ const SummaryHeader = ({
             <Link underline="hover" onClick={() => setShowDetails(SummaryType.Summary)}>
               Summary
             </Link>
-          ) : showDetails === SummaryType.Summary ? (
+          ) : (
             <Typography>
               Summary
             </Typography>
-            ) : <></>
+            )
           }
           {
             showDetails === SummaryType.DetailedSummary &&
@@ -116,7 +120,7 @@ const SummaryHeader = ({
               </Typography>
               <HelpCircle />
             </>
-          ) : showDetails === SummaryType.Summary ? (
+          ) : (
             <>
                 <Box sx={{
                   display: 'flex',
@@ -140,7 +144,7 @@ const SummaryHeader = ({
                   <Button variant="contained">Download results (.csv)</Button>
                 </Box>
               </>
-            ) : <></>
+            )
         }
       </Box>
     </Stack>

--- a/src/components/connections/SummaryInstructions.tsx
+++ b/src/components/connections/SummaryInstructions.tsx
@@ -1,0 +1,35 @@
+import { Box, Typography } from '@mui/material'
+import React from 'react'
+
+const SummaryInstructions = () => {
+	return (
+		<Box>
+			<Typography
+				sx={{
+					textAlign: 'center',
+					marginTop: '2.5rem',
+				}}
+			>Select a square on the connectivity grid to view details of connections.</Typography>
+			<Box
+				sx={{
+					margin: '0 1rem',
+					backgroundColor: '#f5f5f5',
+					borderRadius: '0.5rem',
+					marginTop: '2.5rem',
+					height: '40rem',
+				}}
+			>
+				<Typography
+					className="SummaryInstructions"
+					sx={{
+						fontSize: '1rem',
+						textAlign: 'center',
+					}}
+				>SummaryInstructions</Typography>
+
+			</Box>
+		</Box>
+	)
+}
+
+export default SummaryInstructions

--- a/src/components/graphDiagram/GraphDiagram.tsx
+++ b/src/components/graphDiagram/GraphDiagram.tsx
@@ -10,14 +10,16 @@ import {CanvasWidget} from '@projectstorm/react-canvas-core';
 import {CustomNodeModel} from "./models/CustomNodeModel";
 import {CustomNodeFactory} from "./factories/CustomNodeFactory";
 import {
-    AnatomicalEntity,
-    DestinationSerializerDetails,
-    ForwardConnection,
     NodeTypes,
     TypeB60Enum,
     TypeC11Enum,
-    ViaSerializerDetails
 } from "../../models/composer";
+import {
+    AnatomicalEntity,
+    DestinationExplorerSerializerDetails,
+    ViaExplorerSerializerDetails,
+    ForwardConnection,
+} from "../../models/explorer";
 
 
 export interface CustomNodeOptions extends BasePositionModelOptions {
@@ -40,8 +42,8 @@ const DestinationTypeMapping: Record<TypeC11Enum, string> = {
 
 interface GraphDiagramProps {
     origins: AnatomicalEntity[] | undefined;
-    vias: ViaSerializerDetails[] | undefined;
-    destinations: DestinationSerializerDetails[] | undefined;
+    vias: ViaExplorerSerializerDetails[] | undefined;
+    destinations: DestinationExplorerSerializerDetails[] | undefined;
     forward_connection?: ForwardConnection[] | undefined;
 }
 
@@ -75,8 +77,8 @@ const createLink = (sourceNode: CustomNodeModel, targetNode: CustomNodeModel, so
 
 const processData = (
     origins: AnatomicalEntity[] | undefined,
-    vias: ViaSerializerDetails[] | undefined,
-    destinations: DestinationSerializerDetails[] | undefined,
+    vias: ViaExplorerSerializerDetails[] | undefined,
+    destinations: DestinationExplorerSerializerDetails[] | undefined,
     forward_connection: ForwardConnection[],
 ): { nodes: CustomNodeModel[], links: DefaultLinkModel[] } => {
     const nodes: CustomNodeModel[] = [];
@@ -91,8 +93,8 @@ const processData = (
 
     origins?.forEach(origin => {
         const id = getId(NodeTypes.Origin, origin)
-        const name = origin.simple_entity !== null ? origin.simple_entity.name : origin.region_layer?.region.name + '(' + origin.region_layer?.layer.name + ')';
-        const ontology_uri = origin.simple_entity !== null ? origin.simple_entity.ontology_uri : origin.region_layer?.region.ontology_uri + ', ' + origin.region_layer?.layer.ontology_uri;
+        const name = origin.name
+        const ontology_uri = origin.ontology_uri
         const fws: never[] = []
         const originNode = new CustomNodeModel(
             NodeTypes.Origin,
@@ -116,8 +118,8 @@ const processData = (
         let yVia = layerIndex * yIncrement + yStart;
         via.anatomical_entities.forEach(entity => {
             const id = getId(NodeTypes.Via + layerIndex, entity)
-            const name = entity.simple_entity !== null ? entity.simple_entity.name : entity.region_layer?.region.name + '(' + entity.region_layer?.layer.name + ')';
-            const ontology_uri = entity.simple_entity !== null ? entity.simple_entity.ontology_uri : entity.region_layer?.region.ontology_uri + ', ' + entity.region_layer?.layer.ontology_uri;
+            const name = entity.name
+            const ontology_uri = entity.ontology_uri
             const fws: never[] = []
             const viaNode = new CustomNodeModel(
                 NodeTypes.Via,
@@ -160,10 +162,10 @@ const processData = (
     // Process Destinations
     destinations?.forEach(destination => {
         destination.anatomical_entities.forEach(entity => {
-            const name = entity.simple_entity !== null ? entity.simple_entity.name : entity.region_layer?.region.name + '(' + entity.region_layer?.layer.name + ')';
-            const ontology_uri = entity.simple_entity !== null ? entity.simple_entity.ontology_uri : entity.region_layer?.region.ontology_uri + ', ' + entity.region_layer?.layer.ontology_uri;
+            const name = entity.name
+            const ontology_uri = entity.ontology_uri
             const fws = forward_connection.filter(single_fw => {
-                const origins = single_fw.origins.map((origin: { id: number } | number) => typeof origin === 'object' ? origin.id : origin);
+                const origins = single_fw.origins.map((origin: { id: string } | number) => typeof origin === 'object' ? origin.id : origin);
                 return origins.includes(entity.id);
 
             });

--- a/src/context/DataContext.ts
+++ b/src/context/DataContext.ts
@@ -1,6 +1,7 @@
 import React, {createContext, useContext} from "react";
 import {Organ, HierarchicalNode, KnowledgeStatement} from "../models/explorer";
 import {Option} from "../components/common/Types.ts";
+import { ksMapType } from "../components/common/Types";
 
 export interface Filters {
     Origin: Option[];
@@ -11,6 +12,14 @@ export interface Filters {
     Via: Option[];
 }
 
+
+export interface ConnectionSummary {
+    connections: ksMapType;  // displaying connection 1 of 5
+    origin: string;
+    endOrgan: Organ;
+    hierarchy: HierarchicalNode;
+}
+
 export interface DataContext {
     filters: Filters;
     majorNerves: Set<string>;
@@ -18,6 +27,8 @@ export interface DataContext {
     hierarchicalNodes: Record<string, HierarchicalNode>;
     knowledgeStatements: Record<string, KnowledgeStatement>;
     setFilters: React.Dispatch<React.SetStateAction<Filters>>;
+    selectedConnectionSummary: ConnectionSummary;
+    setConnectionSummary: React.Dispatch<React.SetStateAction<ConnectionSummary>>;
 }
 
 export const DataContext = createContext<DataContext>({
@@ -35,6 +46,14 @@ export const DataContext = createContext<DataContext>({
     knowledgeStatements: {},
     setFilters: () => {
     },
+    selectedConnectionSummary: {
+        connections: {},
+        origin: "",
+        endOrgan: {} as Organ,
+        hierarchy: {} as HierarchicalNode,
+    },
+    setConnectionSummary: () => {
+    }
 });
 
 export const useDataContext = () => useContext(DataContext);

--- a/src/context/DataContext.ts
+++ b/src/context/DataContext.ts
@@ -35,8 +35,8 @@ export interface DataContext {
     knowledgeStatements: Record<string, KnowledgeStatement>;
     setFilters: React.Dispatch<React.SetStateAction<Filters>>;
     setSummaryFilters: React.Dispatch<React.SetStateAction<SummaryFilters>>;
-    selectedConnectionSummary: ConnectionSummary;
-    setConnectionSummary: React.Dispatch<React.SetStateAction<ConnectionSummary>>;
+    selectedConnectionSummary: ConnectionSummary | null;
+    setConnectionSummary: React.Dispatch<React.SetStateAction<ConnectionSummary | null>>;
 }
 
 export const DataContext = createContext<DataContext>({
@@ -60,12 +60,7 @@ export const DataContext = createContext<DataContext>({
     },
     setSummaryFilters: () => {
     },
-    selectedConnectionSummary: {
-        connections: {},
-        origin: "",
-        endOrgan: {} as Organ,
-        hierarchy: {} as HierarchicalNode,
-    },
+    selectedConnectionSummary: null,
     setConnectionSummary: () => {
     }
 });

--- a/src/context/DataContext.ts
+++ b/src/context/DataContext.ts
@@ -34,6 +34,7 @@ export interface DataContext {
     hierarchicalNodes: Record<string, HierarchicalNode>;
     knowledgeStatements: Record<string, KnowledgeStatement>;
     setFilters: React.Dispatch<React.SetStateAction<Filters>>;
+    setSummaryFilters: React.Dispatch<React.SetStateAction<SummaryFilters>>;
     selectedConnectionSummary: ConnectionSummary;
     setConnectionSummary: React.Dispatch<React.SetStateAction<ConnectionSummary>>;
 }
@@ -56,6 +57,8 @@ export const DataContext = createContext<DataContext>({
     hierarchicalNodes: {},
     knowledgeStatements: {},
     setFilters: () => {
+    },
+    setSummaryFilters: () => {
     },
     selectedConnectionSummary: {
         connections: {},

--- a/src/context/DataContext.ts
+++ b/src/context/DataContext.ts
@@ -13,6 +13,12 @@ export interface Filters {
 }
 
 
+export interface SummaryFilters {
+    Phenotype: Option[];
+    Nerve: Option[];
+}
+
+
 export interface ConnectionSummary {
     connections: ksMapType;  // displaying connection 1 of 5
     origin: string;
@@ -22,6 +28,7 @@ export interface ConnectionSummary {
 
 export interface DataContext {
     filters: Filters;
+    summaryFilters: SummaryFilters;
     majorNerves: Set<string>;
     organs: Record<string, Organ>;
     hierarchicalNodes: Record<string, HierarchicalNode>;
@@ -39,6 +46,10 @@ export const DataContext = createContext<DataContext>({
         Phenotype: [],
         apiNATOMY: [],
         Via: []
+    },
+    summaryFilters: {
+        Phenotype: [],
+        Nerve: []
     },
     majorNerves: new Set<string>(),
     organs: {},

--- a/src/context/DataContext.ts
+++ b/src/context/DataContext.ts
@@ -1,7 +1,7 @@
 import React, {createContext, useContext} from "react";
 import {Organ, HierarchicalNode, KnowledgeStatement} from "../models/explorer";
 import {Option} from "../components/common/Types.ts";
-import { ksMapType } from "../components/common/Types";
+import { KsMapType } from "../components/common/Types";
 
 export interface Filters {
     Origin: Option[];
@@ -20,7 +20,7 @@ export interface SummaryFilters {
 
 
 export interface ConnectionSummary {
-    connections: ksMapType;  // displaying connection 1 of 5
+    connections: KsMapType;  // displaying connection 1 of 5
     origin: string;
     endOrgan: Organ;
     hierarchy: HierarchicalNode;

--- a/src/context/DataContextProvider.tsx
+++ b/src/context/DataContextProvider.tsx
@@ -39,6 +39,7 @@ export const DataContextProvider = ({
     const dataContextValue = {
         filters,
         summaryFilters,
+        setSummaryFilters,
         organs,
         majorNerves,
         hierarchicalNodes,

--- a/src/context/DataContextProvider.tsx
+++ b/src/context/DataContextProvider.tsx
@@ -1,5 +1,5 @@
 import {PropsWithChildren, useState} from 'react';
-import { DataContext, Filters, ConnectionSummary } from "./DataContext";
+import { DataContext, Filters, ConnectionSummary, SummaryFilters } from "./DataContext";
 import {HierarchicalNode, KnowledgeStatement, Organ} from "../models/explorer.ts";
 
 
@@ -23,6 +23,10 @@ export const DataContextProvider = ({
         apiNATOMY: [],
         Via: []
     });
+    const [summaryFilters, setSummaryFilters] = useState<SummaryFilters>({
+        Phenotype: [],
+        Nerve: []
+    });
 
     const [selectedConnectionSummary, setSelectedConnectionSummary] = useState<ConnectionSummary>({
         connections: {},
@@ -34,6 +38,7 @@ export const DataContextProvider = ({
 
     const dataContextValue = {
         filters,
+        summaryFilters,
         organs,
         majorNerves,
         hierarchicalNodes,

--- a/src/context/DataContextProvider.tsx
+++ b/src/context/DataContextProvider.tsx
@@ -28,12 +28,7 @@ export const DataContextProvider = ({
         Nerve: []
     });
 
-    const [selectedConnectionSummary, setSelectedConnectionSummary] = useState<ConnectionSummary>({
-        connections: {},
-        origin: "",
-        endOrgan: {} as Organ,
-        hierarchy: {} as HierarchicalNode,
-    });
+    const [selectedConnectionSummary, setSelectedConnectionSummary] = useState<ConnectionSummary | null>(null);
 
 
     const dataContextValue = {

--- a/src/context/DataContextProvider.tsx
+++ b/src/context/DataContextProvider.tsx
@@ -1,14 +1,15 @@
 import {PropsWithChildren, useState} from 'react';
-import {DataContext, Filters} from "./DataContext";
+import { DataContext, Filters, ConnectionSummary } from "./DataContext";
 import {HierarchicalNode, KnowledgeStatement, Organ} from "../models/explorer.ts";
 
+
 export const DataContextProvider = ({
-                                        hierarchicalNodes,
-                                        organs,
-                                        majorNerves,
-                                        knowledgeStatements,
-                                        children
-                                    }: PropsWithChildren<{
+    hierarchicalNodes,
+    organs,
+    majorNerves,
+    knowledgeStatements,
+    children
+}: PropsWithChildren<{
     hierarchicalNodes: Record<string, HierarchicalNode>;
     organs: Record<string, Organ>;
     majorNerves: Set<string>;
@@ -23,6 +24,13 @@ export const DataContextProvider = ({
         Via: []
     });
 
+    const [selectedConnectionSummary, setSelectedConnectionSummary] = useState<ConnectionSummary>({
+        connections: {},
+        origin: "",
+        endOrgan: {} as Organ,
+        hierarchy: {} as HierarchicalNode,
+    });
+
 
     const dataContextValue = {
         filters,
@@ -31,6 +39,8 @@ export const DataContextProvider = ({
         hierarchicalNodes,
         knowledgeStatements,
         setFilters,
+        selectedConnectionSummary,
+        setConnectionSummary: setSelectedConnectionSummary
     };
 
     return (

--- a/src/models/explorer.ts
+++ b/src/models/explorer.ts
@@ -1,3 +1,5 @@
+import { TypeB60Enum, TypeC11Enum } from "./composer";
+
 export interface BaseEntity {
     /**
      *
@@ -26,6 +28,128 @@ export interface AnatomicalEntity extends BaseEntity {
      * @memberof AnatomicalEntity
      */
     synonyms: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AnatomicalEntity
+     */
+    ontology_uri?: string;
+}
+
+
+// The following Serializer uses - AnatomicalEntity from {explorer.ts}
+export interface DestinationExplorerSerializerDetails {
+    /**
+ *
+ * @type {number}
+ * @memberof DestinationSerializerDetails
+ */
+    'id': number;
+    /**
+     *
+     * @type {number}
+     * @memberof DestinationSerializerDetails
+     */
+    'connectivity_statement_id': number;
+    /**
+     *
+     * @type {TypeC11Enum}
+     * @memberof DestinationSerializerDetails
+     */
+    'type'?: TypeC11Enum;
+    /**
+     *
+     * @type {Array<AnatomicalEntity>}
+     * @memberof DestinationSerializerDetails
+     */
+    'anatomical_entities': Array<AnatomicalEntity>;
+    /**
+     *
+     * @type {Array<AnatomicalEntity>}
+     * @memberof DestinationSerializerDetails
+     */
+    'from_entities': Array<AnatomicalEntity>;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof DestinationSerializerDetails
+     */
+    'are_connections_explicit': boolean;
+}
+
+export interface ForwardConnection {
+    id: string;
+    knowledge_statement: string;
+    type: string;
+    origins: AnatomicalEntity[]
+}
+
+export interface ViaExplorerSerializerDetails {
+    /**
+     *
+     * @type {number}
+     * @memberof ViaSerializerDetails
+     */
+    'id': number;
+    /**
+     *
+     * @type {number}
+     * @memberof ViaSerializerDetails
+     */
+    'order': number;
+    /**
+     *
+     * @type {number}
+     * @memberof ViaSerializerDetails
+     */
+    'connectivity_statement_id': number;
+    /**
+     *
+     * @type {TypeB60Enum}
+     * @memberof ViaSerializerDetails
+     */
+    'type'?: TypeB60Enum;
+    /**
+     *
+     * @type {Array<AnatomicalEntity>}
+     * @memberof ViaSerializerDetails
+     */
+    'anatomical_entities': Array<AnatomicalEntity>;
+    /**
+     *
+     * @type {Array<AnatomicalEntity>}
+     * @memberof ViaSerializerDetails
+     */
+    'from_entities': Array<AnatomicalEntity>;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ViaSerializerDetails
+     */
+    'are_connections_explicit': boolean;
+}
+
+
+export interface Sex {
+    // three id - number, name - string, ontology_uri - string
+    /**
+     *
+     * @type {number}
+     * @memberof Sex
+     */
+    id: number;
+    /**
+     *
+     * @type {string}
+     * @memberof Sex
+     */
+    name: string;
+    /**
+     *
+     * @type {string}
+     * @memberof Sex
+     */
+    ontology_uri: string;
 }
 
 export interface KnowledgeStatement {
@@ -55,10 +179,10 @@ export interface KnowledgeStatement {
     species: BaseEntity[];
     /**
      *
-     * @type {Array<AnatomicalEntity>}
+     * @type {Array<ViaExplorerSerializerDetails>}
      * @memberof KnowledgeStatement
      */
-    via: AnatomicalEntity[];
+    via: ViaExplorerSerializerDetails[];
     /**
      *
      * @type {Array<AnatomicalEntity>}
@@ -67,10 +191,10 @@ export interface KnowledgeStatement {
     origins: AnatomicalEntity[];
     /**
      *
-     * @type {Array<AnatomicalEntity>}
+     * @type {Array<DestinationExplorerSerializerDetails>}
      * @memberof KnowledgeStatement
      */
-    destinations: AnatomicalEntity[];
+    destinations: DestinationExplorerSerializerDetails[];
 
     /**
      *
@@ -78,6 +202,63 @@ export interface KnowledgeStatement {
      * @memberof KnowledgeStatement
      */
     forwardConnections: string[];
+
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof KnowledgeStatement
+     */
+    provenances: string[];
+
+    /**
+     * 
+     * @type {string}
+     * @memberof KnowledgeStatement
+     */
+    knowledge_statement: string;
+
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof KnowledgeStatement
+     */
+    journey: string[];
+
+    /**
+     * 
+     * @type {string}
+     * @memberof KnowledgeStatement
+     */
+    laterality: string;
+
+    /**
+     * 
+     * @type {string}
+     * @memberof KnowledgeStatement
+     */
+    projection: string;
+
+    /**
+     * 
+     * @type {string}
+     * @memberof KnowledgeStatement
+     */
+    circuit_type: string;
+
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof KnowledgeStatement
+     */
+    sex: Sex;
+
+    /**
+     * 
+     * @type {string}
+     * @memberof KnowledgeStatement
+     */
+    statement_preview: string;
+
 }
 
 export interface HierarchicalNode {
@@ -94,6 +275,13 @@ export interface HierarchicalNode {
      */
     name: string;
     /**
+     * URI of the node
+     *
+     * @type {string}
+     * @memberof HierarchicalNode
+     */
+    uri: string;
+    /**
      *  The children of the node
      * @type {Array<string>}
      * @memberof HierarchicalNode
@@ -105,4 +293,10 @@ export interface HierarchicalNode {
      * @memberof HierarchicalNode
      */
     connectionDetails?: Record<string, Set<string>>;
+    /**
+     * The sub end organs of the node
+     * @type {Record<string, string[]>}
+     * @memberof HierarchicalNode
+     */
+    endOrgansUri?: Record<string, string[]>;
 }

--- a/src/models/explorer.ts
+++ b/src/models/explorer.ts
@@ -289,14 +289,14 @@ export interface HierarchicalNode {
     children: Set<string>;
     /**
      * The connection details of the node targetOrgan -> KnowledgeStatementsId
-     * @type {Record<string, string[]>}
+     * @type {Record<string, Set<string>>}
      * @memberof HierarchicalNode
      */
     connectionDetails?: Record<string, Set<string>>;
     /**
      * The sub end organs of the node
-     * @type {Record<string, string[]>}
+     * @type {Record<string, Set<string>>}
      * @memberof HierarchicalNode
      */
-    endOrgansUri?: Record<string, string[]>;
+    endOrgansUri?: Record<string, Set<string>>;
 }

--- a/src/models/explorer.ts
+++ b/src/models/explorer.ts
@@ -16,7 +16,7 @@ export interface BaseEntity {
 }
 
 export interface Organ extends BaseEntity {
-    children: Set<BaseEntity>;
+    children: Map<string, BaseEntity>;
 
     order: number;
 }

--- a/src/models/explorer.ts
+++ b/src/models/explorer.ts
@@ -182,7 +182,7 @@ export interface KnowledgeStatement {
      * @type {Array<ViaExplorerSerializerDetails>}
      * @memberof KnowledgeStatement
      */
-    via: ViaExplorerSerializerDetails[];
+    vias: ViaExplorerSerializerDetails[];
     /**
      *
      * @type {Array<AnatomicalEntity>}
@@ -298,5 +298,5 @@ export interface HierarchicalNode {
      * @type {Record<string, Set<string>>}
      * @memberof HierarchicalNode
      */
-    endOrgansUri?: Record<string, Set<string>>;
+    destinationDetails?: Record<string, Set<string>>;
 }

--- a/src/services/filterValuesService.ts
+++ b/src/services/filterValuesService.ts
@@ -47,7 +47,8 @@ export const getUniqueOrigins = (knowledgeStatements: Record<string, KnowledgeSt
 export const getUniqueVias = (knowledgeStatements: Record<string, KnowledgeStatement>): Option[] => {
     let vias: AnatomicalEntity[] = [];
     Object.values(knowledgeStatements).forEach(ks => {
-        vias = vias.concat(ks.via);
+        const anatomical_entities = ks.via.flatMap(via => via.anatomical_entities);
+        vias = vias.concat(anatomical_entities);
     });
     return getUniqueEntities(vias);
 };

--- a/src/services/filterValuesService.ts
+++ b/src/services/filterValuesService.ts
@@ -47,7 +47,7 @@ export const getUniqueOrigins = (knowledgeStatements: Record<string, KnowledgeSt
 export const getUniqueVias = (knowledgeStatements: Record<string, KnowledgeStatement>): Option[] => {
     let vias: AnatomicalEntity[] = [];
     Object.values(knowledgeStatements).forEach(ks => {
-        const anatomical_entities = ks.via.flatMap(via => via.anatomical_entities);
+        const anatomical_entities = ks.vias.flatMap(via => via.anatomical_entities);
         vias = vias.concat(anatomical_entities);
     });
     return getUniqueEntities(vias);

--- a/src/services/heatmapService.ts
+++ b/src/services/heatmapService.ts
@@ -205,7 +205,7 @@ export function getKnowledgeStatementAndCount(ksIds: Set<string>, knowledgeState
     const ksMap: ksMapType = {};
     ksIds.forEach((id: string) => {
         const ks = knowledgeStatements[id];
-        if (ks && !ksMap.hasOwnProperty(id)) {
+        if (ks) {
             ksMap[id] = {
                 'ks': ks,
                 'count': ksMap[id] ? ksMap[id].count + 1 : 1

--- a/src/services/heatmapService.ts
+++ b/src/services/heatmapService.ts
@@ -1,6 +1,6 @@
 import { HierarchicalNode, KnowledgeStatement, Organ } from "../models/explorer.ts";
 import {ROOTS} from "./hierarchyService.ts";
-import { HierarchicalItem, IHeatmapMatrixInformation, Option, KsMapType, LabelIdPair } from "../components/common/Types.ts";
+import { HierarchicalItem, HeatmapMatrixInformation, Option, KsMapType, LabelIdPair } from "../components/common/Types.ts";
 import {Filters} from "../context/DataContext.ts";
 
 export function getYAxis(hierarchicalNodes: Record<string, HierarchicalNode>, hierarchyNode?: Record<string, HierarchicalNode>): HierarchicalItem[] {
@@ -98,7 +98,7 @@ export function calculateConnections(hierarchicalNodes: Record<string, Hierarchi
 
 
 export function getHeatmapData(yAxis: HierarchicalItem[], connections: Map<string, Set<string>[]>) {
-    const heatmapInformation: IHeatmapMatrixInformation = {
+    const heatmapInformation: HeatmapMatrixInformation = {
         heatmapMatrix: [],
         detailedHeatmap: []
     }

--- a/src/services/heatmapService.ts
+++ b/src/services/heatmapService.ts
@@ -1,7 +1,6 @@
-import {HierarchicalNode, KnowledgeStatement, Organ} from "../models/explorer.ts";
-import {HierarchicalItem} from "../components/ConnectivityGrid.tsx";
+import { HierarchicalNode, KnowledgeStatement, Organ } from "../models/explorer.ts";
 import {ROOTS} from "./hierarchyService.ts";
-import { IHeatmapMatrixInformation, Option, ksMapType } from "../components/common/Types.ts";
+import { HierarchicalItem, IHeatmapMatrixInformation, Option, ksMapType } from "../components/common/Types.ts";
 import {Filters} from "../context/DataContext.ts";
 
 export function getYAxis(hierarchicalNodes: Record<string, HierarchicalNode>): HierarchicalItem[] {

--- a/src/services/heatmapService.ts
+++ b/src/services/heatmapService.ts
@@ -185,7 +185,7 @@ export function filterKnowledgeStatements(knowledgeStatements: Record<string, Kn
         const phenotypeMatch = !phenotypeIds.length || phenotypeIds.includes(ks.phenotype);
         const apiNATOMYMatch = !apiNATOMYIds.length || apiNATOMYIds.includes(ks.apinatomy);
         const speciesMatch = !speciesIds.length || ks.species.some(species => speciesIds.includes(species.id));
-        const viaMatch = !viaIds.length || ks.via.some(via => viaIds.includes(via.id.toString()));
+        const viaMatch = !viaIds.length || ks.via.flatMap(v => v.anatomical_entities).some(v => viaIds.includes(v.id));
         const originMatch = !originIds.length || ks.origins.some(origin => originIds.includes(origin.id));
 
         if (phenotypeMatch && apiNATOMYMatch && speciesMatch && viaMatch && originMatch) {

--- a/src/services/heatmapService.ts
+++ b/src/services/heatmapService.ts
@@ -211,7 +211,7 @@ export const getPhenotypeColors = (normalizedValue: number, phenotypeColors: str
     });
 
     // if there are multiple colors, create a linear gradient
-    let phenotypeColor = phenotypeColors.length > 1 ? `linear-gradient(to right, ${phenotypeColorsWithPercentage.join(',')}` :
+    const phenotypeColor = phenotypeColors.length > 1 ? `linear-gradient(to right, ${phenotypeColorsWithPercentage.join(',')}` :
         phenotypeColors.length === 1 ? phenotypeColors[0] : '';
 
     // ADD the following if we need opacity for secondary/phenotype heatmap -  replace the alpha value of the color with the normalized value

--- a/src/services/heatmapService.ts
+++ b/src/services/heatmapService.ts
@@ -185,7 +185,7 @@ export function filterKnowledgeStatements(knowledgeStatements: Record<string, Kn
         const phenotypeMatch = !phenotypeIds.length || phenotypeIds.includes(ks.phenotype);
         const apiNATOMYMatch = !apiNATOMYIds.length || apiNATOMYIds.includes(ks.apinatomy);
         const speciesMatch = !speciesIds.length || ks.species.some(species => speciesIds.includes(species.id));
-        const viaMatch = !viaIds.length || ks.via.flatMap(v => v.anatomical_entities).some(v => viaIds.includes(v.id));
+        const viaMatch = !viaIds.length || ks.vias.flatMap(via => via.anatomical_entities).some(via => viaIds.includes(via.id));
         const originMatch = !originIds.length || ks.origins.some(origin => originIds.includes(origin.id));
 
         if (phenotypeMatch && apiNATOMYMatch && speciesMatch && viaMatch && originMatch) {
@@ -201,15 +201,12 @@ export function getHierarchyFromId(id: string, hierarchicalNodes: Record<string,
 }
 
 
-export function getKnowledgeStatementAndCount(ksIds: Set<string>, knowledgeStatements: Record<string, KnowledgeStatement>): KsMapType {
+export function getKnowledgeStatementMap(ksIds: Set<string>, knowledgeStatements: Record<string, KnowledgeStatement>): KsMapType {
     const ksMap: KsMapType = {};
     ksIds.forEach((id: string) => {
         const ks = knowledgeStatements[id];
         if (ks) {
-            ksMap[id] = {
-                'ks': ks,
-                'count': ksMap[id] ? ksMap[id].count + 1 : 1
-            }
+            ksMap[id] = ks;
         }
     });
     return ksMap;

--- a/src/services/heatmapService.ts
+++ b/src/services/heatmapService.ts
@@ -1,6 +1,6 @@
 import { HierarchicalNode, KnowledgeStatement, Organ } from "../models/explorer.ts";
 import {ROOTS} from "./hierarchyService.ts";
-import { HierarchicalItem, IHeatmapMatrixInformation, Option, ksMapType } from "../components/common/Types.ts";
+import { HierarchicalItem, IHeatmapMatrixInformation, Option, KsMapType } from "../components/common/Types.ts";
 import {Filters} from "../context/DataContext.ts";
 
 export function getYAxis(hierarchicalNodes: Record<string, HierarchicalNode>): HierarchicalItem[] {
@@ -197,12 +197,12 @@ export function filterKnowledgeStatements(knowledgeStatements: Record<string, Kn
 
 
 export function getHierarchyFromId(id: string, hierarchicalNodes: Record<string, HierarchicalNode>): HierarchicalNode {
-    return Object.values(hierarchicalNodes).find(node => node.id === id) as HierarchicalNode;
+    return hierarchicalNodes[id];
 }
 
 
-export function getKnowledgeStatementAndCount(ksIds: Set<string>, knowledgeStatements: Record<string, KnowledgeStatement>): ksMapType {
-    const ksMap: ksMapType = {};
+export function getKnowledgeStatementAndCount(ksIds: Set<string>, knowledgeStatements: Record<string, KnowledgeStatement>): KsMapType {
+    const ksMap: KsMapType = {};
     ksIds.forEach((id: string) => {
         const ks = knowledgeStatements[id];
         if (ks) {
@@ -214,3 +214,21 @@ export function getKnowledgeStatementAndCount(ksIds: Set<string>, knowledgeState
     });
     return ksMap;
 }
+
+export const getPhenotypeColors = (normalizedValue: number, phenotypeColors: string[]): string => {
+    // convert each to percentage values = for linear gradient
+    // example: rgba(131, 0, 191, 0.5) 0%, rgba(131, 0, 191, 0.5) 50%, rgba(131, 0, 191, 0.5) 100%
+    const phenotypeColorsWithPercentage = phenotypeColors.map((color, index) => {
+        return `${color} ${100 / phenotypeColors.length * index}%, ${color} ${100 / phenotypeColors.length * (index + 1)}%`
+    });
+
+    // if there are multiple colors, create a linear gradient
+    let phenotypeColor = phenotypeColors.length > 1 ? `linear-gradient(to right, ${phenotypeColorsWithPercentage.join(',')}` :
+        phenotypeColors.length === 1 ? phenotypeColors[0] : '';
+
+    // replace the alpha value of the color with the normalized value
+    phenotypeColor = phenotypeColor?.replace(/rgba\(([^,]+),([^,]+),([^,]+),([^)]+)\)/g, `rgba($1,$2,$3,${normalizedValue})`).replace(
+        /rgb\(([^,]+),([^,]+),([^,]+)\)/g, `rgba($1,$2,$3,${normalizedValue})`
+    );
+    return phenotypeColor ? phenotypeColor : `rgba(131, 0, 191, ${normalizedValue})`;
+};

--- a/src/services/hierarchyService.ts
+++ b/src/services/hierarchyService.ts
@@ -95,14 +95,14 @@ export const getHierarchicalNodes = (jsonData: JsonData) => {
                     uri: '',
                     children: new Set<string>(),
                     connectionDetails: {},
-                    endOrgansUri: {}
+                    destinationDetails: {}
                 };
                 hierarchicalNodes[leafNodeId] = leafNode;
             }
 
             // Update or initialize connection details
             leafNode.connectionDetails = leafNode.connectionDetails || {};
-            leafNode.endOrgansUri = leafNode.endOrgansUri || {};
+            leafNode.destinationDetails = leafNode.destinationDetails || {};
 
             const neuronId = entry.Neuron_ID?.value;
             let targetOrganIRI = entry.Target_Organ_IRI?.value;
@@ -122,13 +122,13 @@ export const getHierarchicalNodes = (jsonData: JsonData) => {
                 if (!leafNode.connectionDetails[targetOrganIRI]) {
                     leafNode.connectionDetails[targetOrganIRI] = new Set<string>();  // Initialize as an empty set
                 }
-                if (!leafNode.endOrgansUri[endOrganIRI]) {
-                    leafNode.endOrgansUri[endOrganIRI] = new Set<string>(); // Initialize as an empty array
+                if (!leafNode.destinationDetails[endOrganIRI]) {
+                    leafNode.destinationDetails[endOrganIRI] = new Set<string>(); // Initialize as an empty array
                 }
 
                 // Add the KnowledgeStatement to the array for this target organ
                 leafNode.connectionDetails[targetOrganIRI].add(neuronId);
-                leafNode.endOrgansUri[endOrganIRI].add(neuronId);
+                leafNode.destinationDetails[endOrganIRI].add(neuronId);
             } else {
 
                 if (!neuronId) {

--- a/src/services/hierarchyService.ts
+++ b/src/services/hierarchyService.ts
@@ -157,7 +157,7 @@ export const getOrgans = (jsonData: JsonData): Record<string, Organ> => {
     organsRecord[OTHER_X_AXIS_ID] = {
         id: OTHER_X_AXIS_ID,
         name: OTHER_X_AXIS_LABEL,
-        children: new Set<BaseEntity>(),
+        children: new Map<string, BaseEntity>(),
         order: 0
     };
 
@@ -172,17 +172,23 @@ export const getOrgans = (jsonData: JsonData): Record<string, Organ> => {
                 organsRecord[organId] = {
                     id: organId,
                     name: organName,
-                    children: new Set<BaseEntity>(),
+                    children: new Map<string, BaseEntity>(),
                     order: ++creationOrder
                 };
             }
 
             if (childId && childName) {
-                organsRecord[organId].children.add({id: childId, name: childName});
+                const organ = organsRecord[organId];
+                if (!organ.children.has(childId)) {
+                    organ.children.set(childId, {id: childId, name: childName});
+                }
             }
         } else {
             if (childId && childName) {
-                organsRecord[OTHER_X_AXIS_ID].children.add({id: childId, name: childName});
+                const otherOrgan = organsRecord[OTHER_X_AXIS_ID];
+                if (!otherOrgan.children.has(childId)) {
+                    otherOrgan.children.set(childId, {id: childId, name: childName});
+                }
             }
         }
     });

--- a/src/services/mappers.ts
+++ b/src/services/mappers.ts
@@ -1,4 +1,4 @@
-import {AnatomicalEntity} from "../models/composer.ts";
+import { AnatomicalEntity, TypeB60Enum, TypeC11Enum } from "../models/composer.ts";
 import { Sex } from "../models/explorer.ts";
 
 
@@ -62,7 +62,8 @@ export function mapApiResponseToKnowledgeStatements(composerResponse: ComposerRe
             return {
                 ...dest,
                 anatomical_entities: anatomicalEntities,
-                from_entities: fromEntities
+                from_entities: fromEntities,
+                type: dest.type as TypeC11Enum
             }
         }),
         via: ks.vias.flatMap(via => {
@@ -71,7 +72,8 @@ export function mapApiResponseToKnowledgeStatements(composerResponse: ComposerRe
             return {
                 ...via,
                 anatomical_entities: anatomicalEntities,
-                from_entities: fromEntities
+                from_entities: fromEntities,
+                type: via.type as TypeB60Enum
             }
         }),
         forwardConnections: ks.forward_connection.map(fc => fc.reference_uri || ""),

--- a/src/services/mappers.ts
+++ b/src/services/mappers.ts
@@ -1,4 +1,6 @@
 import {AnatomicalEntity} from "../models/composer.ts";
+import { Sex } from "../models/explorer.ts";
+
 
 export interface ComposerResponse {
     count: number;
@@ -13,13 +15,21 @@ interface KnowledgeStatementAPI {
     species: Array<{ name: string, ontology_uri: string }>;
     origins: Array<AnatomicalEntity>;
     destinations: Array<{
-        id: number,
-        anatomical_entities: Array<AnatomicalEntity>
+        id: number;
+        anatomical_entities: Array<AnatomicalEntity>;
+        from_entities: Array<AnatomicalEntity>;
+        type: string;
+        connectivity_statement_id: number;
+        are_connections_explicit: boolean;
     }>;
     vias: Array<{
         id: number;
         type: string;
         anatomical_entities: Array<AnatomicalEntity>;
+        from_entities: Array<AnatomicalEntity>;
+        order: number;
+        connectivity_statement_id: number;
+        are_connections_explicit: boolean;
     }>;
     from_entities: Array<AnatomicalEntity>;
     are_connections_explicit: boolean;
@@ -28,6 +38,14 @@ interface KnowledgeStatementAPI {
     phenotype: { name: string, ontology_uri: string };
     forward_connection: Array<{ reference_uri: string }>;
     reference_uri: string;
+    provenances: Array<{ id: number, uri: string, connectivity_statement_id: number }>;
+    knowledge_statement: string;
+    journey: string[];
+    laterality: string;
+    projection: string;
+    circuit_type: string;
+    sex: Sex;
+    statement_preview: string;
 }
 
 
@@ -38,11 +56,33 @@ export function mapApiResponseToKnowledgeStatements(composerResponse: ComposerRe
         apinatomy: ks.apinatomy_model || "",
         species: ks.species.map(species => getBaseEntity(species.name, species.ontology_uri)),
         origins: ks.origins.map(origin => getAnatomicalEntity(origin)),
-        destinations: ks.destinations.flatMap(dest => dest.anatomical_entities.map(destA => getAnatomicalEntity(destA))),
-        via: ks.vias.flatMap(via => via.anatomical_entities.map(viaA => {
-            return {...getAnatomicalEntity(viaA)}
-        })),
-        forwardConnections: ks.forward_connection.map(fc => fc.reference_uri || "")
+        destinations: ks.destinations.flatMap(dest => {
+            const anatomicalEntities = dest.anatomical_entities.map(destA => getAnatomicalEntity(destA));
+            const fromEntities = dest.from_entities.map(fromE => getAnatomicalEntity(fromE));
+            return {
+                ...dest,
+                anatomical_entities: anatomicalEntities,
+                from_entities: fromEntities
+            }
+        }),
+        via: ks.vias.flatMap(via => {
+            const anatomicalEntities = via.anatomical_entities.map(viaA => getAnatomicalEntity(viaA));
+            const fromEntities = via.from_entities.map(fromE => getAnatomicalEntity(fromE));
+            return {
+                ...via,
+                anatomical_entities: anatomicalEntities,
+                from_entities: fromEntities
+            }
+        }),
+        forwardConnections: ks.forward_connection.map(fc => fc.reference_uri || ""),
+        provenances: ks.provenances?.map(p => p.uri || ""),
+        knowledge_statement: ks.knowledge_statement || "",
+        journey: ks.journey || [],
+        laterality: ks.laterality || "",
+        projection: ks.projection || "",
+        circuit_type: ks.circuit_type || "",
+        sex: ks.sex || [],
+        statement_preview: ks.statement_preview || ""
     }));
 }
 
@@ -58,6 +98,7 @@ const getAnatomicalEntity = (anatomicalEntity: AnatomicalEntity) => {
     return {
         id: getAnatomicalEntityOntologyUri(anatomicalEntity) || "",
         name: getAnatomicalEntityName(anatomicalEntity) || "",
+        ontology_uri: getAnatomicalEntityOntologyUri(anatomicalEntity) || "",
         synonyms: anatomicalEntity.synonyms || ""
     }
 }

--- a/src/services/mappers.ts
+++ b/src/services/mappers.ts
@@ -66,7 +66,7 @@ export function mapApiResponseToKnowledgeStatements(composerResponse: ComposerRe
                 type: dest.type as TypeC11Enum
             }
         }),
-        via: ks.vias.flatMap(via => {
+        vias: ks.vias.flatMap(via => {
             const anatomicalEntities = via.anatomical_entities.map(viaA => getAnatomicalEntity(viaA));
             const fromEntities = via.from_entities.map(fromE => getAnatomicalEntity(fromE));
             return {

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -1,6 +1,6 @@
 // Search origins
-import {Option} from "../components/common/Types.ts";
-import {SYNONYMS_TITLE} from "../settings.ts";
+import { Option } from "../components/common/Types.ts";
+import { SYNONYMS_TITLE } from "../settings.ts";
 
 export const searchOrigins = (searchValue: string, options: Option[]): Option[] => {
     return searchAnatomicalEntities(searchValue, options);
@@ -26,6 +26,13 @@ export const searchVias = (searchValue: string, options: Option[]): Option[] => 
     return searchAnatomicalEntities(searchValue, options);
 };
 
+export const searchNerveFilter = (value: string, nerveOptions: Option[]): Option[] => {
+    return searchByLabel(value, nerveOptions);
+}
+
+export const searchPhenotypeFilter = (value: string, phenotypeOptions: Option[]): Option[] => {
+    return searchByLabel(value, phenotypeOptions);
+}
 
 const searchByLabel = (searchValue: string, options: Option[]): Option[] => {
     const lowerSearchValue = searchValue.toLowerCase();

--- a/src/services/summaryHeatmapService.ts
+++ b/src/services/summaryHeatmapService.ts
@@ -1,0 +1,221 @@
+
+import { HierarchicalItem, ISubConnections, ksMapType } from "../components/common/Types.ts";
+import { ConnectionSummary, SummaryFilters } from "../context/DataContext.ts";
+import { HierarchicalNode, KnowledgeStatement, Organ } from "../models/explorer.ts";
+import { PhenotypeDetail } from "../components/common/Types.ts";
+
+
+export const checkIfConnectionSummaryIsEmpty = (connectionSummary: ConnectionSummary): boolean => {
+	return Object.values(connectionSummary).every((value) => {
+		if (Array.isArray(value)) {
+			return value.length === 0;
+		}
+		if (typeof value === 'object') {
+			return checkIfConnectionSummaryIsEmpty(value);
+		}
+		return value === "";
+	});
+}
+
+export const generatePhenotypeColors = (num: number) => {
+	// some fixed colors for phenotypes - 4 colors
+	const colors = [
+		'rgba(155, 24, 216, 1)',
+		'rgba(44, 44, 206, 1)',
+		'rgba(220, 104, 3, 1)',
+		'rgba(234, 170, 8, 1)',
+	];
+	for (let i = 4; i < num; i++) {
+		colors.push(`rgb(${Math.floor(Math.random() * 256)}, ${Math.floor(Math.random() * 256)}, ${Math.floor(Math.random() * 256)})`);
+	}
+	return colors;
+}
+
+export function convertViaToString(via: string[]): string {
+	if (via.length === 0) return '-';
+	if (via.length > 1) {
+		return via.join(', ').replace(/,(?=[^,]*$)/, ' and');
+	}
+	return via[0];
+}
+
+export function getAllViasFromConnections(connections: ksMapType): { [key: string]: string } {
+	let vias: { [key: string]: string } = {};
+	Object.values(connections).forEach(connection => {
+		if (connection.ks.via && connection.ks.via.length > 0) {
+			const flattenedVias = connection.ks.via.flatMap(via => via.anatomical_entities);
+			flattenedVias.forEach(via => {
+				vias[via.id] = via.name;
+			});
+		}
+	});
+	return vias;
+}
+
+export function getAllPhenotypes(connections: ksMapType): string[] {
+	const phenotypeNames: Set<string> = new Set();
+	Object.values(connections).forEach(connection => {
+		if (connection.ks?.phenotype) {
+			phenotypeNames.add(connection.ks.phenotype);
+		} else {
+			phenotypeNames.add('other');
+		}
+	});
+	return Array.from(phenotypeNames)
+}
+
+export const getNerveFilters = (viasConnection: { [key: string]: string }, majorNerves: Set<string>) => {
+	let nerves: { [key: string]: string } = {};
+	Object.keys(viasConnection).forEach(via => {
+		if (Array.from(majorNerves).includes(via)) {
+			nerves[via] = viasConnection[via];
+		}
+	});
+	return nerves;
+}
+
+export function getYAxisNode(node: HierarchicalItem, yAxisCon: HierarchicalNode): HierarchicalItem {
+	if (node?.id === yAxisCon?.id) {
+		return node;
+	}
+	if (node.children) {
+		let found = false;
+		for (let child of node.children) {
+			if (found) break;
+			const nodeFound = getYAxisNode(child, yAxisCon);
+			if (nodeFound?.id) {
+				found = true;
+				return nodeFound;
+			}
+		}
+	}
+
+	return {} as HierarchicalItem;
+}
+
+
+export function getSecondaryHeatmapData(yAxis: HierarchicalItem[], connections: Map<string, ISubConnections[]>) {
+	const newData: ISubConnections[][] = [];
+
+	function addDataForItem(item: HierarchicalItem) {
+		const itemData = connections.get(item.id);
+		if (itemData) {
+			newData.push(itemData);
+		}
+	}
+
+	function traverseItems(items: HierarchicalItem[], fetchNextLevel: boolean) {
+		items?.forEach(item => {
+			if (item.expanded) {
+				// Fetch data for the current expanded item
+				addDataForItem(item);
+				// Traverse further into the expanded item
+				if (item.children && typeof item.children[0] !== 'string') {
+					traverseItems(item.children as HierarchicalItem[], true);
+				}
+			} else if (fetchNextLevel) {
+				// Fetch data for the immediate children of the last expanded item
+				addDataForItem(item);
+			}
+		});
+	}
+
+	// Start traversal with the initial yAxis, allowing to fetch immediate children of the root if expanded
+	traverseItems(yAxis, true);
+
+	return newData;
+}
+
+export function summaryFilterKnowledgeStatements(knowledgeStatements: Record<string, KnowledgeStatement>, summaryFilters: SummaryFilters): Record<string, KnowledgeStatement> {
+	return knowledgeStatements;
+}
+
+export function calculateSecondaryConnections(
+	hierarchicalNodes: Record<string, HierarchicalNode>, endorgans: Record<string, Organ>,
+	allKnowledgeStatements: Record<string, KnowledgeStatement>, summaryFilters: SummaryFilters,
+	phenotypes: PhenotypeDetail[]
+): Map<string, ISubConnections[]> {
+
+	// Apply filters to organs and knowledge statements
+	let knowledgeStatements = summaryFilterKnowledgeStatements(allKnowledgeStatements, summaryFilters);
+
+	// Create a map of organ IRIs to their index positions for quick lookup
+	// const sortedOrgans = Object.values(allOrgans).sort((a, b) => a.order - b.order);
+	const organIndexMap = Object.values(endorgans).reduce<Record<string, number>>((map, organ, index) => {
+		map[organ.id] = index;
+		return map;
+	}, {});
+
+	// Memoization map to store computed results for nodes
+	const memo = new Map<string, ISubConnections[]>();
+
+	// Function to compute node connections with memoization
+	function computeNodeConnections(nodeId: string): ISubConnections[] {
+		if (memo.has(nodeId)) {
+			return memo.get(nodeId)!;
+		}
+
+		const node = hierarchicalNodes[nodeId];
+		const result: ISubConnections[] = Object.values(endorgans).map(organ => ({ count: 0, color: [], ksIds: new Set<string>() }));
+		if (node.children && node.children.size > 0) {
+			node.children.forEach(childId => {
+				const childConnections = computeNodeConnections(childId);
+				childConnections.forEach((child, index) => {
+					result[index].count += child.count;
+					result[index].color = [...new Set([...result[index].color, ...child.color])];
+					result[index].ksIds = new Set([...result[index].ksIds, ...child.ksIds]);
+				});
+			});
+		} else if (node.endOrgansUri || node.connectionDetails) {
+			if (node.endOrgansUri) {
+				// Add the sub end organs to the connection details
+				Object.keys(node.endOrgansUri).forEach(endOrganIRI => {
+					const index = organIndexMap[endOrganIRI];
+					node.endOrgansUri = node.endOrgansUri || {}; // Keeps linter happy
+					if (index !== undefined) {
+						const knowledgeStatementIds = Array.from(node.endOrgansUri[endOrganIRI])
+							.filter(ksId => ksId in knowledgeStatements);
+
+						if (knowledgeStatementIds.length === 0) {
+							result[index].count += 0;
+							result[index].color = []
+
+						} else {
+							const ksPhenotypes = knowledgeStatementIds.map(ksId => knowledgeStatements[ksId].phenotype).filter(phenotype => phenotype !== '');
+							const phenotypeColorsSet = new Set<string>();
+
+							const unknownFilter = phenotypes.find(p => p.label === 'other');
+							ksPhenotypes.length === 0 ? phenotypeColorsSet.add(unknownFilter?.color || '') :
+								ksPhenotypes.map(phenotype => {
+									const phn = phenotypes.find(p => p.label === phenotype);
+									phn ? phenotypeColorsSet.add(phn.color) : phenotypeColorsSet.add(unknownFilter?.color || '')  // FIXME: Could be a bug
+								})
+
+							const phenotypeColors = Array.from(phenotypeColorsSet)
+							result[index].count += knowledgeStatementIds.length;
+							result[index].color = phenotypeColors
+							result[index].ksIds = new Set([...result[index].ksIds, ...knowledgeStatementIds]);
+						}
+					}
+				});
+			}
+		}
+
+		memo.set(nodeId, result);
+		return result;
+	}
+
+	const connectionsMap = new Map<string, ISubConnections[]>();
+	Object.values(hierarchicalNodes).forEach(node => {
+		connectionsMap.set(node.id, computeNodeConnections(node.id));
+	});
+	return connectionsMap;
+}
+
+
+export const getNormalizedValueForMinMax = (value: number, min: number, max: number): number => {
+	// keep the min 0 always... 
+	// Ex. for situations where min is 4... the value 4 will not be shown...
+	min = 0;
+	return max !== min ? (value - min) / (max - min) : 1;
+}

--- a/src/services/summaryHeatmapService.ts
+++ b/src/services/summaryHeatmapService.ts
@@ -1,5 +1,5 @@
 
-import { HierarchicalItem, ISubConnections, ksMapType } from "../components/common/Types.ts";
+import { HierarchicalItem, ISubConnections, KsMapType } from "../components/common/Types.ts";
 import { ConnectionSummary, SummaryFilters } from "../context/DataContext.ts";
 import { HierarchicalNode, KnowledgeStatement, Organ } from "../models/explorer.ts";
 import { PhenotypeDetail } from "../components/common/Types.ts";
@@ -39,7 +39,7 @@ export function convertViaToString(via: string[]): string {
 	return via[0];
 }
 
-export function getAllViasFromConnections(connections: ksMapType): { [key: string]: string } {
+export function getAllViasFromConnections(connections: KsMapType): { [key: string]: string } {
 	const vias: { [key: string]: string } = {};
 	Object.values(connections).forEach(connection => {
 		if (connection.ks.via && connection.ks.via.length > 0) {
@@ -52,7 +52,7 @@ export function getAllViasFromConnections(connections: ksMapType): { [key: strin
 	return vias;
 }
 
-export function getAllPhenotypes(connections: ksMapType): string[] {
+export function getAllPhenotypes(connections: KsMapType): string[] {
 	const phenotypeNames: Set<string> = new Set();
 	Object.values(connections).forEach(connection => {
 		if (connection.ks?.phenotype) {

--- a/src/services/summaryHeatmapService.ts
+++ b/src/services/summaryHeatmapService.ts
@@ -6,6 +6,7 @@ import { PhenotypeDetail } from "../components/common/Types.ts";
 import { FIXED_FOUR_PHENOTYPE_COLORS_ARRAY, OTHER_PHENOTYPE_LABEL } from "../settings.ts";
 
 
+
 export const generatePhenotypeColors = (num: number) => {
 	const colors: string[] = FIXED_FOUR_PHENOTYPE_COLORS_ARRAY;
 	for (let i = 4; i < num; i++) {
@@ -37,7 +38,7 @@ export function getAllViasFromConnections(connections: KsMapType): { [key: strin
 
 export function getAllPhenotypes(connections: KsMapType): string[] {
 	const phenotypeNames: Set<string> = new Set();
-	Object.values(connections).forEach(connection => {
+	Object.values(connections)?.forEach(connection => {
 		if (connection?.phenotype) {
 			phenotypeNames.add(connection.phenotype);
 		} else {
@@ -112,21 +113,25 @@ export function getSecondaryHeatmapData(yAxis: HierarchicalItem[], connections: 
 export function summaryFilterKnowledgeStatements(knowledgeStatements: Record<string, KnowledgeStatement>, summaryFilters: SummaryFilters): Record<string, KnowledgeStatement> {
 	const phenotypeIds = summaryFilters.Phenotype.map(option => option.id);
 	const nerveIds = summaryFilters.Nerve.map(option => option.id);
-	console.log(phenotypeIds, nerveIds);
-	return knowledgeStatements;
+	return Object.entries(knowledgeStatements).reduce((filtered, [id, ks]) => {
+		const phenotypeMatch = !phenotypeIds.length || phenotypeIds.includes(ks.phenotype);
+		const nerveMatch = !nerveIds.length || ks.vias?.some(via => via.anatomical_entities.map(entity => entity.id).some(id => nerveIds.includes(id)));
+		if (phenotypeMatch && nerveMatch) {
+			filtered[id] = ks;
+		}
+		return filtered;
+	}, {} as Record<string, KnowledgeStatement>);
 }
 
 export function calculateSecondaryConnections(
 	hierarchicalNodes: Record<string, HierarchicalNode>, endorgans: Record<string, Organ>,
 	allKnowledgeStatements: Record<string, KnowledgeStatement>, summaryFilters: SummaryFilters,
-	phenotypes: PhenotypeDetail[]
+	phenotypes: PhenotypeDetail[], hierarchyNode: HierarchicalNode
 ): Map<string, SubConnections[]> {
 
 	// Apply filters to organs and knowledge statements
 	const knowledgeStatements = summaryFilterKnowledgeStatements(allKnowledgeStatements, summaryFilters);
 
-	// Create a map of organ IRIs to their index positions for quick lookup
-	// const sortedOrgans = Object.values(allOrgans).sort((a, b) => a.order - b.order);
 	const organIndexMap = Object.values(endorgans).reduce<Record<string, number>>((map, organ, index) => {
 		map[organ.id] = index;
 		return map;
@@ -142,60 +147,49 @@ export function calculateSecondaryConnections(
 		}
 
 		const node = hierarchicalNodes[nodeId];
-		const result: SubConnections[] = Object.values(endorgans).map(() => ({ count: 0, colors: [], ksIds: new Set<string>() }));
+		const result: SubConnections[] = Object.values(endorgans).map(() => ({ colors: [], ksIds: new Set<string>() }));
 		if (node.children && node.children.size > 0) {
 			node.children.forEach(childId => {
 				const childConnections = computeNodeConnections(childId);
 				childConnections.forEach((child, index) => {
-					result[index].count += child.count;
 					result[index].colors = [...new Set([...result[index].colors, ...child.colors])];
 					result[index].ksIds = new Set([...result[index].ksIds, ...child.ksIds]);
 				});
 			});
-		} else if (node.destinationDetails || node.connectionDetails) {
-			if (node.destinationDetails) {
-				// Add the sub end organs to the connection details
-				Object.keys(node.destinationDetails).forEach(endOrganIRI => {
-					const index = organIndexMap[endOrganIRI];
-					node.destinationDetails = node.destinationDetails || {}; // Keeps linter happy
-					if (index !== undefined) {
-						const knowledgeStatementIds = Array.from(node.destinationDetails[endOrganIRI])
-							.filter(ksId => ksId in knowledgeStatements);
+		} else if (node.destinationDetails) {
+			// Add the sub end organs to the connection details
+			Object.keys(node.destinationDetails).forEach(endOrganIRI => {
+				const index = organIndexMap[endOrganIRI];
+				node.destinationDetails = node.destinationDetails || {}; // Keeps linter happy
+				if (index !== undefined) {
+					const knowledgeStatementIds = Array.from(node.destinationDetails[endOrganIRI])
+						.filter(ksId => ksId in knowledgeStatements);
 
-						if (knowledgeStatementIds.length === 0) {
-							result[index].count += 0;
-							result[index].colors = []
+					if (knowledgeStatementIds.length > 0) {
+						const ksPhenotypes = knowledgeStatementIds.map(ksId => knowledgeStatements[ksId].phenotype).filter(phenotype => phenotype !== '');
+						const phenotypeColorsSet = new Set<string>();
 
-						} else {
-							const ksPhenotypes = knowledgeStatementIds.map(ksId => knowledgeStatements[ksId].phenotype).filter(phenotype => phenotype !== '');
-							const phenotypeColorsSet = new Set<string>();
+						const unknownFilter = phenotypes.find(p => p.label === OTHER_PHENOTYPE_LABEL);
+						ksPhenotypes.length === 0 ? phenotypeColorsSet.add(unknownFilter?.color || '') :
+							ksPhenotypes.map(phenotype => {
+								const phn = phenotypes.find(p => p.label === phenotype);
+								phn ? phenotypeColorsSet.add(phn.color) : phenotypeColorsSet.add(unknownFilter?.color || '')  // FIXME: Could be a bug
+							})
 
-							const unknownFilter = phenotypes.find(p => p.label === OTHER_PHENOTYPE_LABEL);
-							ksPhenotypes.length === 0 ? phenotypeColorsSet.add(unknownFilter?.color || '') :
-								ksPhenotypes.map(phenotype => {
-									const phn = phenotypes.find(p => p.label === phenotype);
-									phn ? phenotypeColorsSet.add(phn.color) : phenotypeColorsSet.add(unknownFilter?.color || '')  // FIXME: Could be a bug
-								})
-
-							const phenotypeColors = Array.from(phenotypeColorsSet)
-							result[index].count += knowledgeStatementIds.length;
-							result[index].colors = phenotypeColors
-							result[index].ksIds = new Set([...result[index].ksIds, ...knowledgeStatementIds]);
-						}
+						const phenotypeColors = Array.from(phenotypeColorsSet)
+						result[index].colors = phenotypeColors
+						result[index].ksIds = new Set([...result[index].ksIds, ...knowledgeStatementIds]);
 					}
-				});
-			}
+				}
+			});
 		}
 
 		memo.set(nodeId, result);
 		return result;
 	}
 
-	const connectionsMap = new Map<string, SubConnections[]>();
-	Object.values(hierarchicalNodes).forEach(node => {
-		connectionsMap.set(node.id, computeNodeConnections(node.id));
-	});
-	return connectionsMap;
+	computeNodeConnections(hierarchyNode.id)
+	return memo;
 }
 
 
@@ -203,6 +197,7 @@ export const getNormalizedValueForMinMax = (value: number, min: number, max: num
 	// keep the min 0 always... 
 	// Ex. for situations where min is 4... the value 4 will not be shown...
 	min = 0;
+	if (max === 0) return 0;
 	return max !== min ? (value - min) / (max - min) : 1;
 }
 

--- a/src/services/summaryHeatmapService.ts
+++ b/src/services/summaryHeatmapService.ts
@@ -40,7 +40,7 @@ export function convertViaToString(via: string[]): string {
 }
 
 export function getAllViasFromConnections(connections: ksMapType): { [key: string]: string } {
-	let vias: { [key: string]: string } = {};
+	const vias: { [key: string]: string } = {};
 	Object.values(connections).forEach(connection => {
 		if (connection.ks.via && connection.ks.via.length > 0) {
 			const flattenedVias = connection.ks.via.flatMap(via => via.anatomical_entities);
@@ -65,7 +65,7 @@ export function getAllPhenotypes(connections: ksMapType): string[] {
 }
 
 export const getNerveFilters = (viasConnection: { [key: string]: string }, majorNerves: Set<string>) => {
-	let nerves: { [key: string]: string } = {};
+	const nerves: { [key: string]: string } = {};
 	Object.keys(viasConnection).forEach(via => {
 		if (Array.from(majorNerves).includes(via)) {
 			nerves[via] = viasConnection[via];
@@ -80,7 +80,7 @@ export function getYAxisNode(node: HierarchicalItem, yAxisCon: HierarchicalNode)
 	}
 	if (node.children) {
 		let found = false;
-		for (let child of node.children) {
+		for (const child of node.children) {
 			if (found) break;
 			const nodeFound = getYAxisNode(child, yAxisCon);
 			if (nodeFound?.id) {
@@ -127,6 +127,9 @@ export function getSecondaryHeatmapData(yAxis: HierarchicalItem[], connections: 
 }
 
 export function summaryFilterKnowledgeStatements(knowledgeStatements: Record<string, KnowledgeStatement>, summaryFilters: SummaryFilters): Record<string, KnowledgeStatement> {
+	const phenotypeIds = summaryFilters.Phenotype.map(option => option.id);
+	const nerveIds = summaryFilters.Nerve.map(option => option.id);
+	console.log(phenotypeIds, nerveIds);
 	return knowledgeStatements;
 }
 
@@ -137,7 +140,7 @@ export function calculateSecondaryConnections(
 ): Map<string, ISubConnections[]> {
 
 	// Apply filters to organs and knowledge statements
-	let knowledgeStatements = summaryFilterKnowledgeStatements(allKnowledgeStatements, summaryFilters);
+	const knowledgeStatements = summaryFilterKnowledgeStatements(allKnowledgeStatements, summaryFilters);
 
 	// Create a map of organ IRIs to their index positions for quick lookup
 	// const sortedOrgans = Object.values(allOrgans).sort((a, b) => a.order - b.order);
@@ -156,7 +159,7 @@ export function calculateSecondaryConnections(
 		}
 
 		const node = hierarchicalNodes[nodeId];
-		const result: ISubConnections[] = Object.values(endorgans).map(organ => ({ count: 0, color: [], ksIds: new Set<string>() }));
+		const result: ISubConnections[] = Object.values(endorgans).map(() => ({ count: 0, color: [], ksIds: new Set<string>() }));
 		if (node.children && node.children.size > 0) {
 			node.children.forEach(childId => {
 				const childConnections = computeNodeConnections(childId);

--- a/src/services/summaryHeatmapService.ts
+++ b/src/services/summaryHeatmapService.ts
@@ -3,6 +3,7 @@ import { HierarchicalItem, SubConnections, KsMapType } from "../components/commo
 import { ConnectionSummary, SummaryFilters } from "../context/DataContext.ts";
 import { HierarchicalNode, KnowledgeStatement, Organ } from "../models/explorer.ts";
 import { PhenotypeDetail } from "../components/common/Types.ts";
+import { FIXED_FOUR_PHENOTYPE_COLORS_ARRAY } from "../settings.ts";
 
 
 export const checkIfConnectionSummaryIsEmpty = (connectionSummary: ConnectionSummary): boolean => {
@@ -18,13 +19,7 @@ export const checkIfConnectionSummaryIsEmpty = (connectionSummary: ConnectionSum
 }
 
 export const generatePhenotypeColors = (num: number) => {
-	// some fixed colors for phenotypes - 4 colors
-	const colors = [
-		'rgba(155, 24, 216, 1)',
-		'rgba(44, 44, 206, 1)',
-		'rgba(220, 104, 3, 1)',
-		'rgba(234, 170, 8, 1)',
-	];
+	const colors: string[] = FIXED_FOUR_PHENOTYPE_COLORS_ARRAY;
 	for (let i = 4; i < num; i++) {
 		colors.push(`rgb(${Math.floor(Math.random() * 256)}, ${Math.floor(Math.random() * 256)}, ${Math.floor(Math.random() * 256)})`);
 	}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,7 +6,7 @@ export const COMPOSER_API_URL = "https://composer.sckan.dev.metacell.us/api"
 
 export const OTHER_X_AXIS_ID = 'OTHER_X'
 export const OTHER_X_AXIS_LABEL = 'Other'
-
+export const OTHER_PHENOTYPE_LABEL = 'other'
 export const SYNONYMS_TITLE = "synonyms"
 
 export const FIXED_FOUR_PHENOTYPE_COLORS_ARRAY = [

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,3 +9,9 @@ export const OTHER_X_AXIS_LABEL = 'Other'
 
 export const SYNONYMS_TITLE = "synonyms"
 
+export const FIXED_FOUR_PHENOTYPE_COLORS_ARRAY = [
+	'rgba(155, 24, 216, 1)',
+	'rgba(44, 44, 206, 1)',
+	'rgba(220, 104, 3, 1)',
+	'rgba(234, 170, 8, 1)',
+]


### PR DESCRIPTION
Jira link - https://metacell.atlassian.net/browse/ESCKAN-20


Task description
- Integrates - summary, summary heatmap, and summary details
- Phenotype colors 
- Adds Default Summary Instruction page
- Table View in summary details
- Graph View in summary details
- Center the loader

- update the models for new Knowledge statement Export from Composer

Important Services added
- getSecondaryHeatmapData - this returns of the format - `ISubConnections[][]` - this is mainly helpful in - getting phenotype Colors in `getCellBgColorFromPhenotype` function in Heatmap.tsx
- calculateSecondaryConnections - this returns of the format - `Map<string, ISubConnections[]>` - this again is helpful in getting the colors along with the `ksIds` - eventually helping in Heatmap.tsx.

<br>

Please note - Legends in the secondary heatmap has "other" - to show all the KS that do not have any phenotypes at all.

<br>
<br>


Things to notice:

> `node.endOrganIRI` in calculateSecondaryConnections() - summaryHeatmapService.ts
AND 
getHierarchicalNodes() -> hierarchyService.ts

This calculates the endorgan using `B_ID` - we use this to calculate the secondary connections.




