### PR TITLE
ESCKAN-53 fix: Fix summary details heatmap

### DIFF
--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -116,12 +116,18 @@ function Connections() {
   const handleCellClick = (x: number, y: number, yId: string): void => {
     // when the heatmap cell is clicked
     setSelectedCell({ x, y });
-    setConnectionPage(1)
     const row = connectionsMap.get(yId);
-    if (selectedConnectionSummary && Object.keys(selectedConnectionSummary.connections).length !== 0 && row) {
-      setShowConnectionDetails(SummaryType.DetailedSummary)
-      const ksMap = getKnowledgeStatementMap(row[x].ksIds, knowledgeStatements);
-      setUniqueKS(ksMap);
+    if (row) {
+      setConnectionPage(1)
+      const ksIds = Object.values(row[x]).reduce((acc, phenotypeData) => {
+        return new Set([...acc, ...phenotypeData.ksIds]);
+      }, new Set<string>());
+
+      if (selectedConnectionSummary && Object.keys(selectedConnectionSummary.connections).length !== 0) {
+        setShowConnectionDetails(SummaryType.DetailedSummary);
+        const ksMap = getKnowledgeStatementMap(ksIds, knowledgeStatements);
+        setUniqueKS(ksMap);
+      }
     }
   }
 

--- a/src/components/common/HeatmapTooltip.tsx
+++ b/src/components/common/HeatmapTooltip.tsx
@@ -1,14 +1,19 @@
 import { FC } from "react";
 import { vars } from "../../theme/variables";
 import { Box, Tooltip, Typography } from "@mui/material";
-const {  gray25, gray300 } = vars;
+const { gray25, gray300 } = vars;
+
+export interface HeatmapTooltipRow {
+  color?: string;
+  name?: string;
+  count: number;
+}
 
 interface HeatmapTooltipProps {
-  value: number;
-  x: number;
-  y: number;
-  secondary?: boolean;
-  getCellBgColor: (value: number) => string;
+  x: string;
+  y: string;
+  connections: number;
+  rows?: HeatmapTooltipRow[];
 }
 
 const commonHeadingStyles = {
@@ -24,79 +29,52 @@ const commonTextStyles = {
   lineHeight: '1.125rem',
   color: gray25,
 }
-const HeatmapTooltip: FC<HeatmapTooltipProps> = ({value, x, y, secondary, getCellBgColor}) => {
-  let data;
-  if (secondary) {
-    data = (
-      <Box minWidth={140}>
-        <Typography sx={{
-          ...commonHeadingStyles,
-          marginBottom: '0.125rem'
 
-        }}>{`${y} -> ${x}`}</Typography>
-        <Box display='flex' flexDirection='column' gap={'0.25rem'}>
-          <Box display='flex' alignItems='center' justifyContent='space-between'>
-            <Box gap='0.375rem' display='flex' alignItems='center'>
-              <Box sx={{
-                width: '1.4794rem', 
-                height: '1rem', 
-                background: getCellBgColor(value)
-              }} 
-              />
-              <Typography sx={commonTextStyles}>
-                {x}
-              </Typography>
-            </Box>
-            <Typography sx={commonTextStyles}>
-              {value}
-            </Typography>
-          </Box>
+const HeatmapTooltip: FC<HeatmapTooltipProps> = ({ x, y, connections, rows }) => {
+  const hasRows = rows && rows.length > 0;
 
-          <Box display='flex' justifyContent='space-between'>
-            <Box gap='0.375rem' display='flex' alignItems='center'>
-              <Box sx={{
-                width: '1.4794rem', 
-                height: '1rem', 
-                background: getCellBgColor(value)
-              }} 
-              />
-              <Typography sx={{...commonTextStyles,
-                lineHeight: '1'
-              }}>
-                {y}
-              </Typography>
-            </Box>
-            <Typography sx={commonTextStyles}>
-              {value}
-            </Typography>
-          </Box>
-        </Box>
-      </Box>
-    )
-  } else {
-    data = (
-      <Box>
-        <Typography sx={{...commonTextStyles,
-          fontWeight: 500,
-          color: gray300
-        }}>{`${y} -> ${x}`}</Typography>
-        <Typography sx={
-          {...commonTextStyles,
-          marginTop: '0.125rem'
-        }}>{`${value}`} connections</Typography>
-      </Box>
-    )
-  }
   return (
-    <Tooltip
-      arrow
-      placement="right"
-      title={data}
-    >
-      <Box sx={{ opacity: 0 }}>{value}</Box>
-    </Tooltip>
+      <Tooltip
+          arrow
+          placement="right"
+          title={
+            <Box minWidth={140}>
+              <Typography sx={{
+                ...commonHeadingStyles,
+                marginBottom: '0.125rem'
+              }}>{`${y} -> ${x}`}</Typography>
+              <Box display='flex' flexDirection='column' gap={'0.25rem'}>
+                {hasRows ? (
+                    rows.map((row, index) => (
+                        <Box key={index} display='flex' alignItems='center' justifyContent='space-between'>
+                          <Box gap='0.375rem' display='flex' alignItems='center'>
+                            <Box sx={{
+                              width: '1.4794rem',
+                              height: '1rem',
+                              background: row.color || 'transparent'
+                            }}
+                            />
+                            <Typography sx={commonTextStyles}>
+                              {row.name || ''}
+                            </Typography>
+                          </Box>
+                          <Typography sx={commonTextStyles}>
+                            {row.count}
+                          </Typography>
+                        </Box>
+                    ))
+                ) : (
+                    <Typography sx={{ ...commonTextStyles, marginTop: '0.125rem' }}>
+                      {`${connections} connections`}
+                    </Typography>
+                )}
+              </Box>
+            </Box>
+          }
+      >
+        <Box sx={{ opacity: 0 }}>{x}</Box>
+      </Tooltip>
   )
 }
 
 export default HeatmapTooltip;
-  

--- a/src/components/common/Types.ts
+++ b/src/components/common/Types.ts
@@ -15,8 +15,11 @@ export type LabelIdPair = { labels: string[], ids: string[] };
 
 export type KsMapType = Record<string, KnowledgeStatement>;
 
-export type PhenotypeKsIdMap = { phenotypes: string[], ksIds: Set<string> };
-
+export type PhenotypeKsIdMap = {
+  [phenotype: string]: {
+    ksIds: Set<string>;
+  };
+};
 // SummaryType - Three types of summary views - default - instruction. 
 // When user clicks the primary heatmap, the summary view will be displayed.
 // When user clicks the secondary heatmap, the detailed summary view will be displayed.


### PR DESCRIPTION
closes https://metacell.atlassian.net/browse/ESCKAN-53

- Changes PhenotypeKsIdMap to map phenotypes to knowledge statement ids instead of having it with 2 flat unrelated lists (this change allow us to understand the count per phenotype)
- Adds lookup table from x,y axis to indexes so that we can know at the cellRender level where to get the necessary information from secondaryHeatmapData for the tooltip
- Updates heatmap tooltip to work in a generic way.

![image](https://github.com/MetaCell/sckan-explorer/assets/19196034/b2ecba56-99c1-47f9-bb69-1b695ea99e7c)
![image](https://github.com/MetaCell/sckan-explorer/assets/19196034/e18f430f-1e9b-47b9-a9a1-2bf37afb5cc7)
