### PR TITLE
Feature/esckan-55

### DIFF
--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -51,6 +51,14 @@ const styles = {
 };
 
 function Connections() {
+  const {
+    selectedConnectionSummary,
+    majorNerves,
+    hierarchicalNodes,
+    knowledgeStatements,
+    filters,
+  } = useDataContext();
+
   const [showConnectionDetails, setShowConnectionDetails] =
     useState<SummaryType>(SummaryType.Instruction);
   const [connectionsMap, setConnectionsMap] = useState<
@@ -66,15 +74,13 @@ function Connections() {
     useState<KsMapType>({});
   const [xAxis, setXAxis] = useState<string[]>([]);
   const [nerveFilters, setNerveFilters] = useState<Option[]>([]);
-  const [phenotypeFilters, setPhenotypeFilters] = useState<Option[]>([]);
+  const [phenotypeFilters, setPhenotypeFilters] = useState<Option[]>(
+    filters.Phenotype,
+  );
 
-  const {
-    selectedConnectionSummary,
-    majorNerves,
-    hierarchicalNodes,
-    knowledgeStatements,
-    filters,
-  } = useDataContext();
+  useEffect(() => {
+    setPhenotypeFilters(filters.Phenotype);
+  }, [filters.Phenotype]);
 
   const summaryFilters = useMemo(
     () => ({
@@ -82,7 +88,7 @@ function Connections() {
       Nerve: nerveFilters,
       Phenotype: phenotypeFilters,
     }),
-    [filters, nerveFilters],
+    [filters, nerveFilters, phenotypeFilters],
   );
 
   useEffect(() => {
@@ -102,6 +108,13 @@ function Connections() {
   ).length;
 
   const availableNerves = getNerveFilters(viasConnection, majorNerves);
+  const availablePhenotypes = useMemo(
+    () =>
+      selectedConnectionSummary
+        ? getAllPhenotypes(selectedConnectionSummary.connections)
+        : [],
+    [selectedConnectionSummary],
+  );
 
   useEffect(() => {
     // calculate the connectionsMap for the secondary heatmap
@@ -127,11 +140,6 @@ function Connections() {
     knowledgeStatements,
   ]);
 
-  const availablePhenotypes = useMemo(
-    () => getAllPhenotypes(connectionsMap),
-    [connectionsMap],
-  );
-
   useEffect(() => {
     // set the xAxis for the heatmap
     if (selectedConnectionSummary) {
@@ -147,7 +155,7 @@ function Connections() {
     if (selectedConnectionSummary && hierarchicalNodes) {
       const hierarchyNode = {
         [selectedConnectionSummary.hierarchy.id]:
-          selectedConnectionSummary.hierarchy,
+        selectedConnectionSummary.hierarchy,
       };
       const yHierarchicalItem = getYAxis(hierarchicalNodes, hierarchyNode);
       setYAxis(yHierarchicalItem);

--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -7,6 +7,7 @@ import {
   PhenotypeKsIdMap,
   SummaryType,
   KsMapType,
+  Option,
 } from './common/Types';
 import { useDataContext } from '../context/DataContext.ts';
 import {
@@ -64,14 +65,25 @@ function Connections() {
   const [knowledgeStatementsMap, setKnowledgeStatementsMap] =
     useState<KsMapType>({});
   const [xAxis, setXAxis] = useState<string[]>([]);
+  const [nerveFilters, setNerveFilters] = useState<Option[]>([]);
+  const [phenotypeFilters, setPhenotypeFilters] = useState<Option[]>([]);
 
   const {
     selectedConnectionSummary,
     majorNerves,
     hierarchicalNodes,
     knowledgeStatements,
-    summaryFilters,
+    filters,
   } = useDataContext();
+
+  const summaryFilters = useMemo(
+    () => ({
+      ...filters,
+      Nerve: nerveFilters,
+      Phenotype: phenotypeFilters,
+    }),
+    [filters, nerveFilters],
+  );
 
   useEffect(() => {
     // By default on the first render, show the instruction/summary
@@ -88,7 +100,8 @@ function Connections() {
   const totalConnectionCount = Object.keys(
     selectedConnectionSummary?.connections || ({} as KsMapType),
   ).length;
-  const nerves = getNerveFilters(viasConnection, majorNerves);
+
+  const availableNerves = getNerveFilters(viasConnection, majorNerves);
 
   useEffect(() => {
     // calculate the connectionsMap for the secondary heatmap
@@ -114,7 +127,7 @@ function Connections() {
     knowledgeStatements,
   ]);
 
-  const selectedPhenotypes = useMemo(
+  const availablePhenotypes = useMemo(
     () => getAllPhenotypes(connectionsMap),
     [connectionsMap],
   );
@@ -256,8 +269,12 @@ function Connections() {
               </Typography>
             </Box>
             <SummaryFiltersDropdown
-              nerves={nerves}
-              phenotypes={selectedPhenotypes}
+              nerves={availableNerves}
+              nerveFilters={nerveFilters}
+              setNerveFilters={setNerveFilters}
+              phenotypes={availablePhenotypes}
+              phenotypeFilters={phenotypeFilters}
+              setPhenotypeFilters={setPhenotypeFilters}
             />
             <HeatmapGrid
               yAxis={yAxis}
@@ -271,7 +288,7 @@ function Connections() {
             />
           </Box>
 
-          <PhenotypeLegend phenotypes={selectedPhenotypes} />
+          <PhenotypeLegend phenotypes={availablePhenotypes} />
         </>
       )}
     </Box>

--- a/src/components/ConnectivityGrid.tsx
+++ b/src/components/ConnectivityGrid.tsx
@@ -75,10 +75,10 @@ function ConnectivityGrid() {
   }, [hierarchicalNodes]);
 
   const { heatmapData, detailedHeatmapData } = useMemo(() => {
-    const heatmapdata = getHeatmapData(yAxis, connectionsMap);
+    const heatmapData = getHeatmapData(yAxis, connectionsMap);
     return {
-      heatmapData: heatmapdata.heatmapMatrix,
-      detailedHeatmapData: heatmapdata.detailedHeatmap,
+      heatmapData: heatmapData.heatmapMatrix,
+      detailedHeatmapData: heatmapData.detailedHeatmap,
     };
   }, [yAxis, connectionsMap]);
 

--- a/src/components/ConnectivityGrid.tsx
+++ b/src/components/ConnectivityGrid.tsx
@@ -31,6 +31,7 @@ function ConnectivityGrid() {
     organs,
     knowledgeStatements,
     filters,
+    setFilters,
     setSelectedConnectionSummary,
   } = useDataContext();
 
@@ -44,6 +45,7 @@ function ConnectivityGrid() {
     x: number;
     y: number;
   } | null>(null);
+  const [initialYAxis, setInitialYAxis] = useState<HierarchicalItem[]>([]);
 
   useEffect(() => {
     const connections = calculateConnections(
@@ -71,6 +73,7 @@ function ConnectivityGrid() {
   useEffect(() => {
     const yAxis = getYAxis(hierarchicalNodes);
     setYAxis(yAxis);
+    setInitialYAxis(yAxis);
   }, [hierarchicalNodes]);
 
   const { heatmapData, detailedHeatmapData } = useMemo(() => {
@@ -98,6 +101,20 @@ function ConnectivityGrid() {
       });
     }
   };
+
+  const handleReset = () => {
+    setYAxis(initialYAxis);
+    setFilters({
+      Origin: [],
+      EndOrgan: [],
+      Species: [],
+      Phenotype: [],
+      apiNATOMY: [],
+      Via: [],
+    });
+    setSelectedCell(null);
+  };
+
   const isLoading = yAxis.length == 0;
 
   return isLoading ? (
@@ -154,6 +171,7 @@ function ConnectivityGrid() {
               background: 'transparent',
             },
           }}
+          onClick={handleReset}
         >
           Reset grid
         </Button>

--- a/src/components/ConnectivityGrid.tsx
+++ b/src/components/ConnectivityGrid.tsx
@@ -6,7 +6,6 @@ import { useDataContext } from '../context/DataContext.ts';
 import {
   calculateConnections,
   getMinMaxConnections,
-  getHierarchyFromId,
   getXAxisOrgans,
   getYAxis,
   getHeatmapData,
@@ -32,7 +31,7 @@ function ConnectivityGrid() {
     organs,
     knowledgeStatements,
     filters,
-    setConnectionSummary,
+    setSelectedConnectionSummary,
   } = useDataContext();
 
   const [yAxis, setYAxis] = useState<HierarchicalItem[]>([]);
@@ -88,15 +87,14 @@ function ConnectivityGrid() {
     const row = connectionsMap.get(yId);
     if (row) {
       const endOrgan = xAxisOrgans[x];
-      const origin = detailedHeatmapData[y];
-      const hierarchy = getHierarchyFromId(origin.id, hierarchicalNodes);
+      const nodeData = detailedHeatmapData[y];
+      const hierarchicalNode = hierarchicalNodes[nodeData.id];
       const ksMap = getKnowledgeStatementMap(row[x], knowledgeStatements);
 
-      setConnectionSummary({
-        origin: origin.label,
-        endOrgan: endOrgan,
+      setSelectedConnectionSummary({
         connections: ksMap,
-        hierarchy: hierarchy,
+        endOrgan: endOrgan,
+        hierarchicalNode: hierarchicalNode,
       });
     }
   };

--- a/src/components/SummaryFiltersDropdown.tsx
+++ b/src/components/SummaryFiltersDropdown.tsx
@@ -8,8 +8,10 @@ import {
 } from '../services/searchService';
 import { OTHER_PHENOTYPE_LABEL } from '../settings';
 
+type FilterKey = 'Phenotype' | 'Nerve';
+
 interface FilterConfig {
-  id: 'Phenotype' | 'Nerve';
+  id: FilterKey;
   placeholder: string;
   searchPlaceholder: string;
 }
@@ -70,8 +72,6 @@ const SummaryFiltersDropdown = ({
   );
 
   const nerveOptions = useMemo(() => convertNervesToOptions(nerves), [nerves]);
-
-  type FilterKey = 'Phenotype' | 'Nerve';
 
   const filterStateMap: {
     [K in FilterKey]: {

--- a/src/components/SummaryPage.tsx
+++ b/src/components/SummaryPage.tsx
@@ -150,13 +150,15 @@ const SummaryPage = () => {
       }
       if (filteredItem.length) {
         return {
-          label: item?.model?.value + '  (' + item?.neuron_category?.value + ')',
+          label:
+            item?.model?.value + '  (' + item?.neuron_category?.value + ')',
           count: item?.count?.value,
           change: item.count.value - filteredItem[0].count.value,
         };
       } else {
         return {
-          label: item?.model?.value + '  (' + item?.neuron_category?.value + ')',
+          label:
+            item?.model?.value + '  (' + item?.neuron_category?.value + ')',
           count: item?.count?.value,
           change: 0,
         };

--- a/src/components/common/CustomFilterDropdown.tsx
+++ b/src/components/common/CustomFilterDropdown.tsx
@@ -21,11 +21,7 @@ import ClearOutlinedIcon from '@mui/icons-material/ClearOutlined';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { vars } from '../../theme/variables';
-
-type OptionDetail = {
-  title: string; // What to display as the title/label for the property.
-  value: string; // The actual value/content for the property.
-};
+import { Option } from './Types.ts';
 
 const {
   gray100,
@@ -38,13 +34,6 @@ const {
   primaryPurple300,
   gray50,
 } = vars;
-
-export type Option = {
-  id: string;
-  label: string;
-  group: string;
-  content: OptionDetail[];
-};
 
 const transition = {
   transition: 'all ease-in-out .3s',

--- a/src/components/common/Types.ts
+++ b/src/components/common/Types.ts
@@ -13,7 +13,7 @@ export type Option = {
 
 export type LabelIdPair = { labels: string[]; ids: string[] };
 
-export type KsMapType = Record<string, KnowledgeStatement>;
+export type KsRecord = Record<string, KnowledgeStatement>;
 
 export type PhenotypeKsIdMap = {
   [phenotype: string]: {

--- a/src/components/connections/SummaryDetails.tsx
+++ b/src/components/connections/SummaryDetails.tsx
@@ -6,7 +6,7 @@ import PopulationDisplay from './PopulationDisplay.tsx';
 import CommonAccordion from '../common/Accordion.tsx';
 import CommonChip from '../common/CommonChip.tsx';
 import { ArrowOutward } from '../icons/index.tsx';
-import { KsMapType } from '../common/Types.ts';
+import { KsRecord } from '../common/Types.ts';
 import { getConnectionDetails } from '../../services/summaryHeatmapService.ts';
 
 const { gray500, gray700, gray800 } = vars;
@@ -43,7 +43,7 @@ const RowStack = ({
 );
 
 type SummaryDetailsProps = {
-  knowledgeStatementsMap: KsMapType;
+  knowledgeStatementsMap: KsRecord;
   connectionPage: number;
 };
 

--- a/src/components/connections/SummaryHeader.tsx
+++ b/src/components/connections/SummaryHeader.tsx
@@ -11,7 +11,7 @@ import { vars } from '../../theme/variables';
 import IconButton from '@mui/material/IconButton';
 import { ArrowDown, ArrowRight, ArrowUp, HelpCircle } from '../icons';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
-import { SummaryType, KsMapType } from '../common/Types';
+import { SummaryType, KsRecord } from '../common/Types';
 import { useDataContext } from '../../context/DataContext.ts';
 
 const { gray100, gray600A, gray500 } = vars;
@@ -19,7 +19,7 @@ const { gray100, gray600A, gray500 } = vars;
 type SummaryHeaderProps = {
   showDetails: SummaryType;
   setShowDetails: (showDetails: SummaryType) => void;
-  knowledgeStatementsMap: KsMapType;
+  knowledgeStatementsMap: KsRecord;
   connectionPage: number;
   setConnectionPage: (connectionPage: number) => void;
   totalConnectionCount: number;

--- a/src/context/DataContext.ts
+++ b/src/context/DataContext.ts
@@ -16,8 +16,7 @@ export interface Filters {
   Via: Option[];
 }
 
-export interface SummaryFilters {
-  Phenotype: Option[];
+export interface SummaryFilters extends Filters {
   Nerve: Option[];
 }
 
@@ -30,13 +29,11 @@ export interface ConnectionSummary {
 
 export interface DataContext {
   filters: Filters;
-  summaryFilters: SummaryFilters;
   majorNerves: Set<string>;
   organs: Record<string, Organ>;
   hierarchicalNodes: Record<string, HierarchicalNode>;
   knowledgeStatements: Record<string, KnowledgeStatement>;
   setFilters: React.Dispatch<React.SetStateAction<Filters>>;
-  setSummaryFilters: React.Dispatch<React.SetStateAction<SummaryFilters>>;
   selectedConnectionSummary: ConnectionSummary | null;
   setConnectionSummary: React.Dispatch<
     React.SetStateAction<ConnectionSummary | null>
@@ -53,18 +50,15 @@ export const DataContext = createContext<DataContext>({
     apiNATOMY: [],
     Via: [],
   },
-  summaryFilters: {
-    Phenotype: [],
-    Nerve: [],
-  },
   majorNerves: new Set<string>(),
   organs: {},
   hierarchicalNodes: {},
   knowledgeStatements: {},
-  setFilters: () => {},
-  setSummaryFilters: () => {},
+  setFilters: () => {
+  },
   selectedConnectionSummary: null,
-  setConnectionSummary: () => {},
+  setConnectionSummary: () => {
+  },
   phenotypesColorMap: {},
 });
 

--- a/src/context/DataContext.ts
+++ b/src/context/DataContext.ts
@@ -5,7 +5,7 @@ import {
   KnowledgeStatement,
 } from '../models/explorer';
 import { Option, PhenotypeDetail } from '../components/common/Types.ts';
-import { KsMapType } from '../components/common/Types';
+import { KsRecord } from '../components/common/Types';
 
 export interface Filters {
   Origin: Option[];
@@ -21,10 +21,10 @@ export interface SummaryFilters extends Filters {
 }
 
 export interface ConnectionSummary {
-  connections: KsMapType; // displaying connection 1 of 5
-  origin: string;
+  connections: KsRecord;
+  filteredKnowledgeStatements: KsRecord;
+  hierarchicalNode: HierarchicalNode;
   endOrgan: Organ;
-  hierarchy: HierarchicalNode;
 }
 
 export interface DataContext {
@@ -35,9 +35,9 @@ export interface DataContext {
   knowledgeStatements: Record<string, KnowledgeStatement>;
   setFilters: React.Dispatch<React.SetStateAction<Filters>>;
   selectedConnectionSummary: ConnectionSummary | null;
-  setConnectionSummary: React.Dispatch<
-    React.SetStateAction<ConnectionSummary | null>
-  >;
+  setSelectedConnectionSummary: (
+    summary: Omit<ConnectionSummary, 'filteredKnowledgeStatements'>,
+  ) => void;
   phenotypesColorMap: Record<string, PhenotypeDetail>;
 }
 
@@ -56,7 +56,7 @@ export const DataContext = createContext<DataContext>({
   knowledgeStatements: {},
   setFilters: () => {},
   selectedConnectionSummary: null,
-  setConnectionSummary: () => {},
+  setSelectedConnectionSummary: () => {},
   phenotypesColorMap: {},
 });
 

--- a/src/context/DataContext.ts
+++ b/src/context/DataContext.ts
@@ -54,11 +54,9 @@ export const DataContext = createContext<DataContext>({
   organs: {},
   hierarchicalNodes: {},
   knowledgeStatements: {},
-  setFilters: () => {
-  },
+  setFilters: () => {},
   selectedConnectionSummary: null,
-  setConnectionSummary: () => {
-  },
+  setConnectionSummary: () => {},
   phenotypesColorMap: {},
 });
 

--- a/src/context/DataContextProvider.tsx
+++ b/src/context/DataContextProvider.tsx
@@ -1,10 +1,5 @@
-import { PropsWithChildren, useMemo, useState } from 'react';
-import {
-  DataContext,
-  Filters,
-  ConnectionSummary,
-  SummaryFilters,
-} from './DataContext';
+import { PropsWithChildren, useEffect, useMemo, useState } from 'react';
+import { DataContext, Filters, ConnectionSummary } from './DataContext';
 import {
   HierarchicalNode,
   KnowledgeStatement,
@@ -13,6 +8,7 @@ import {
 import { PhenotypeDetail } from '../components/common/Types.ts';
 import { generatePhenotypeColors } from '../services/summaryHeatmapService.ts';
 import { OTHER_PHENOTYPE_LABEL } from '../settings.ts';
+import { filterKnowledgeStatements } from '../services/heatmapService.ts';
 
 export const DataContextProvider = ({
   hierarchicalNodes,
@@ -33,10 +29,6 @@ export const DataContextProvider = ({
     Phenotype: [],
     apiNATOMY: [],
     Via: [],
-  });
-  const [summaryFilters, setSummaryFilters] = useState<SummaryFilters>({
-    Phenotype: [],
-    Nerve: [],
   });
 
   const [selectedConnectionSummary, setSelectedConnectionSummary] =
@@ -61,17 +53,45 @@ export const DataContextProvider = ({
     return colorMap;
   }, [phenotypes]);
 
+  const handleSetSelectedConnectionSummary = (
+    summary: Omit<ConnectionSummary, 'filteredKnowledgeStatements'>,
+  ) => {
+    const filteredKnowledgeStatements = filterKnowledgeStatements(
+      summary.connections,
+      filters,
+    );
+    setSelectedConnectionSummary({
+      ...summary,
+      filteredKnowledgeStatements,
+    });
+  };
+
+  useEffect(() => {
+    if (selectedConnectionSummary) {
+      const filteredKnowledgeStatements = filterKnowledgeStatements(
+        selectedConnectionSummary.connections,
+        filters,
+      );
+      setSelectedConnectionSummary((prevSummary) =>
+        prevSummary
+          ? {
+              ...prevSummary,
+              filteredKnowledgeStatements,
+            }
+          : null,
+      );
+    }
+  }, [filters]);
+
   const dataContextValue = {
     filters,
-    summaryFilters,
-    setSummaryFilters,
     organs,
     majorNerves,
     hierarchicalNodes,
     knowledgeStatements,
     setFilters,
     selectedConnectionSummary,
-    setConnectionSummary: setSelectedConnectionSummary,
+    setSelectedConnectionSummary: handleSetSelectedConnectionSummary,
     phenotypesColorMap,
   };
 

--- a/src/services/heatmapService.ts
+++ b/src/services/heatmapService.ts
@@ -8,10 +8,10 @@ import {
   HierarchicalItem,
   HeatmapMatrixInformation,
   Option,
-  KsMapType,
+  KsRecord,
   LabelIdPair,
 } from '../components/common/Types.ts';
-import { Filters, SummaryFilters } from '../context/DataContext.ts';
+import { Filters } from '../context/DataContext.ts';
 
 export function getYAxis(
   hierarchicalNodes: Record<string, HierarchicalNode>,
@@ -207,7 +207,7 @@ export function filterOrgans(
 
 export function filterKnowledgeStatements(
   knowledgeStatements: Record<string, KnowledgeStatement>,
-  filters: Filters | SummaryFilters,
+  filters: Filters,
 ): Record<string, KnowledgeStatement> {
   const phenotypeIds = filters.Phenotype.map((option) => option.id);
   const apiNATOMYIds =
@@ -215,8 +215,6 @@ export function filterKnowledgeStatements(
   const speciesIds = filters.Species?.flatMap((option) => option.id) || [];
   const viaIds = filters.Via?.flatMap((option) => option.id) || [];
   const originIds = filters.Origin?.flatMap((option) => option.id) || [];
-  const nerveIds =
-    (filters as SummaryFilters).Nerve?.map((option) => option.id) || [];
 
   return Object.entries(knowledgeStatements).reduce(
     (filtered, [id, ks]) => {
@@ -235,21 +233,13 @@ export function filterKnowledgeStatements(
       const originMatch =
         !originIds.length ||
         ks.origins?.some((origin) => originIds.includes(origin.id));
-      const nerveMatch =
-        !nerveIds.length ||
-        ks.vias?.some((via) =>
-          via.anatomical_entities
-            .map((entity) => entity.id)
-            .some((id) => nerveIds.includes(id)),
-        );
 
       if (
         phenotypeMatch &&
         apiNATOMYMatch &&
         speciesMatch &&
         viaMatch &&
-        originMatch &&
-        nerveMatch
+        originMatch
       ) {
         filtered[id] = ks;
       }
@@ -258,18 +248,12 @@ export function filterKnowledgeStatements(
     {} as Record<string, KnowledgeStatement>,
   );
 }
-export function getHierarchyFromId(
-  id: string,
-  hierarchicalNodes: Record<string, HierarchicalNode>,
-): HierarchicalNode {
-  return hierarchicalNodes[id];
-}
 
 export function getKnowledgeStatementMap(
   ksIds: string[],
   knowledgeStatements: Record<string, KnowledgeStatement>,
-): KsMapType {
-  const ksMap: KsMapType = {};
+): KsRecord {
+  const ksMap: KsRecord = {};
   ksIds.forEach((id: string) => {
     const ks = knowledgeStatements[id];
     if (ks) {

--- a/src/services/summaryHeatmapService.ts
+++ b/src/services/summaryHeatmapService.ts
@@ -12,6 +12,7 @@ import {
   BaseEntity,
 } from '../models/explorer.ts';
 import { OTHER_PHENOTYPE_LABEL } from '../settings.ts';
+import { filterKnowledgeStatements } from './heatmapService.ts';
 
 export const generatePhenotypeColors = (num: number) => {
   const scale = chroma
@@ -79,32 +80,6 @@ export const getNerveFilters = (
   return nerves;
 };
 
-export function summaryFilterKnowledgeStatements(
-  knowledgeStatements: Record<string, KnowledgeStatement>,
-  summaryFilters: SummaryFilters,
-): Record<string, KnowledgeStatement> {
-  const phenotypeIds = summaryFilters.Phenotype.map((option) => option.id);
-  const nerveIds = summaryFilters.Nerve.map((option) => option.id);
-  return Object.entries(knowledgeStatements).reduce(
-    (filtered, [id, ks]) => {
-      const phenotypeMatch =
-        !phenotypeIds.length || phenotypeIds.includes(ks.phenotype);
-      const nerveMatch =
-        !nerveIds.length ||
-        ks.vias?.some((via) =>
-          via.anatomical_entities
-            .map((entity) => entity.id)
-            .some((id) => nerveIds.includes(id)),
-        );
-      if (phenotypeMatch && nerveMatch) {
-        filtered[id] = ks;
-      }
-      return filtered;
-    },
-    {} as Record<string, KnowledgeStatement>,
-  );
-}
-
 // NOTE: this function is similar to /services/heatmapService.ts - getHeatmapData
 // output type - PhenotypeKsIdMap[][]
 // ***** Recursive function - traverseItems *****
@@ -160,7 +135,7 @@ export function calculateSecondaryConnections(
   hierarchyNode: HierarchicalNode,
 ): Map<string, PhenotypeKsIdMap[]> {
   // Apply filters to organs and knowledge statements
-  const knowledgeStatements = summaryFilterKnowledgeStatements(
+  const knowledgeStatements = filterKnowledgeStatements(
     allKnowledgeStatements,
     summaryFilters,
   );

--- a/src/services/summaryHeatmapService.ts
+++ b/src/services/summaryHeatmapService.ts
@@ -47,21 +47,15 @@ export function getAllViasFromConnections(connections: KsMapType): {
   return vias;
 }
 
-export function getAllPhenotypes(
-  connections: Map<string, PhenotypeKsIdMap[]>,
-): string[] {
+export function getAllPhenotypes(connections: KsMapType): string[] {
   const phenotypeNames: Set<string> = new Set();
 
-  connections.forEach((phenotypeKsIdMaps) => {
-    phenotypeKsIdMaps.forEach((phenotypeKsIdMap) => {
-      Object.keys(phenotypeKsIdMap).forEach((phenotype) => {
-        if (phenotype) {
-          phenotypeNames.add(phenotype);
-        } else {
-          phenotypeNames.add(OTHER_PHENOTYPE_LABEL);
-        }
-      });
-    });
+  Object.values(connections).forEach((ks) => {
+    if (ks.phenotype) {
+      phenotypeNames.add(ks.phenotype);
+    } else {
+      phenotypeNames.add(OTHER_PHENOTYPE_LABEL);
+    }
   });
 
   return Array.from(phenotypeNames).sort();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -24,7 +24,7 @@ export const DATABASE_FILES = {
 };
 
 // TODO: To change to the env variable when the deployment gets integrated with other sckan projects @dario
-export const COMPOSER_API_URL = 'https://composer.sckan.dev.metacell.us/api';
+export const COMPOSER_API_URL = 'https://composer.scicrunch.io/api';
 //export const COMPOSER_API_URL = import.meta.env.VITE_COMPOSER_API_URL
 
 export const OTHER_X_AXIS_ID = 'OTHER_X';


### PR DESCRIPTION
Disclaimer: The current PR is targeting feature/ESCKAN-51 per @ddelpiano request. 

Closes https://metacell.atlassian.net/browse/ESCKAN-55

- Removes summary filters from context and instead adds state variables for nerves and phenotype filters on the connections component.
- Adds filtered knowledge statements to the selectedConnectionSummary context variable (calculated automatically every time the main filters change)
- Updates calculateSecondaryConnections to use the filtered knowledge statements for the calculations
- Get phenotypes now gets the data from the selected connection filtered knowledge statements

- Renames some properties and methods


https://github.com/MetaCell/sckan-explorer/assets/19196034/b4787ac1-3800-424d-80ae-afd8f30456e1


- Connects reset grid button