### PR TITLE
Feature/ESCKAN-60

### DIFF
--- a/public/order.json
+++ b/public/order.json
@@ -2,7 +2,7 @@
   "http://purl.obolibrary.org/obo/UBERON_0005844": [
     "http://purl.obolibrary.org/obo/UBERON_0002726",
     "http://purl.obolibrary.org/obo/UBERON_0003038",
-    "http://purl.obolibrary.org/obo/UBERON_0005843",
-    "http://purl.obolibrary.org/obo/UBERON_0002792"
+    "http://purl.obolibrary.org/obo/UBERON_0002792",
+    "http://purl.obolibrary.org/obo/UBERON_0005843"
   ]
 }

--- a/public/order.json
+++ b/public/order.json
@@ -1,0 +1,8 @@
+{
+  "http://purl.obolibrary.org/obo/UBERON_0005844": [
+    "http://purl.obolibrary.org/obo/UBERON_0002726",
+    "http://purl.obolibrary.org/obo/UBERON_0005843",
+    "http://purl.obolibrary.org/obo/UBERON_0003038",
+    "http://purl.obolibrary.org/obo/UBERON_0002792"
+  ]
+}

--- a/public/order.json
+++ b/public/order.json
@@ -1,8 +1,8 @@
 {
   "http://purl.obolibrary.org/obo/UBERON_0005844": [
     "http://purl.obolibrary.org/obo/UBERON_0002726",
-    "http://purl.obolibrary.org/obo/UBERON_0005843",
     "http://purl.obolibrary.org/obo/UBERON_0003038",
+    "http://purl.obolibrary.org/obo/UBERON_0005843",
     "http://purl.obolibrary.org/obo/UBERON_0002792"
   ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import {
   fetchJSON,
   fetchKnowledgeStatements,
   fetchMajorNerves,
+  fetchOrderJson,
 } from './services/fetchService.ts';
 import { getUniqueMajorNerves } from './services/filterValuesService.ts';
 import {
@@ -62,25 +63,25 @@ const App = () => {
   }, [LayoutComponent, dispatch]);
 
   useEffect(() => {
-    fetchJSON()
-      .then((data) => {
-        setHierarchicalNodes(getHierarchicalNodes(data));
-        setOrgans(getOrgans(data));
-      })
-      .catch((error) => {
-        // TODO: We should give feedback to the user
-        console.error('Failed to fetch JSON data:', error);
-      });
+    const fetchData = async () => {
+      try {
+        const [jsonData, orderData, majorNervesData] = await Promise.all([
+          fetchJSON(),
+          fetchOrderJson(),
+          fetchMajorNerves(),
+        ]);
 
-    fetchMajorNerves()
-      .then((data) => {
-        setMajorNerves(getUniqueMajorNerves(data));
-      })
-      .catch((error) => {
+        setHierarchicalNodes(getHierarchicalNodes(jsonData, orderData));
+        setOrgans(getOrgans(jsonData));
+        setMajorNerves(getUniqueMajorNerves(majorNervesData));
+      } catch (error) {
         // TODO: We should give feedback to the user
-        console.error('Failed to fetch major nerves data:', error);
+        console.error('Failed to fetch data:', error);
         setMajorNerves(undefined);
-      });
+      }
+    };
+
+    fetchData();
   }, []);
 
   useEffect(() => {

--- a/src/models/json.ts
+++ b/src/models/json.ts
@@ -39,6 +39,10 @@ export interface JsonData {
   results: Result;
 }
 
+export interface OrderJson {
+  [nodeId: string]: string[];
+}
+
 interface NerveData {
   type: string;
   value: string;

--- a/src/services/fetchService.ts
+++ b/src/services/fetchService.ts
@@ -2,34 +2,41 @@ import {
   COMPOSER_API_URL,
   SCKAN_JSON_URL,
   SCKAN_MAJOR_NERVES_JSON_URL,
+  SCKAN_ORDER_JSON_URL,
 } from '../settings.ts';
 import { KnowledgeStatement } from '../models/explorer.ts';
 import { mapApiResponseToKnowledgeStatements } from './mappers.ts';
+import { JsonData, NerveResponse, OrderJson } from '../models/json.ts';
 
 const KNOWLEDGE_STATEMENTS_BATCH_SIZE = 100;
 
-export const fetchJSON = async () => {
+const fetchData = async <T>(url: string): Promise<T> => {
   try {
-    const response = await fetch(SCKAN_JSON_URL);
+    const response = await fetch(url);
     if (!response.ok) {
       throw new Error(`${response.statusText}`);
     }
     return await response.json();
   } catch (error) {
-    throw new Error(`Error fetching json data: ${error}`);
+    throw new Error(`Error fetching data from ${url}: ${error}`);
   }
 };
 
-export const fetchMajorNerves = async () => {
+export const fetchJSON = async (): Promise<JsonData> => {
+  return await fetchData<JsonData>(SCKAN_JSON_URL);
+};
+
+export const fetchOrderJson = async (): Promise<OrderJson> => {
   try {
-    const response = await fetch(SCKAN_MAJOR_NERVES_JSON_URL);
-    if (!response.ok) {
-      throw new Error(`${response.statusText}`);
-    }
-    return await response.json();
+    return await fetchData<OrderJson>(SCKAN_ORDER_JSON_URL);
   } catch (error) {
-    throw new Error(`Error fetching major nerves data: ${error}`);
+    console.warn('Failed to fetch order JSON:', error);
+    return {};
   }
+};
+
+export const fetchMajorNerves = async (): Promise<NerveResponse> => {
+  return await fetchData<NerveResponse>(SCKAN_MAJOR_NERVES_JSON_URL);
 };
 
 export const fetchKnowledgeStatements = async (neuronIds: string[]) => {

--- a/src/services/hierarchyService.ts
+++ b/src/services/hierarchyService.ts
@@ -152,24 +152,35 @@ export const getHierarchicalNodes = (
   Object.values(hierarchicalNodes).forEach((node) => {
     if (node.children) {
       node.children = new Set(
-        Array.from(node.children).sort((a, b) => {
-          const nodeA = hierarchicalNodes[a];
-          const nodeB = hierarchicalNodes[b];
+        Array.from(node.children).sort((nodeAPath, nodeBPath) => {
+          const nodeA = hierarchicalNodes[nodeAPath];
+          const nodeB = hierarchicalNodes[nodeBPath];
+
+          // First, compare based on whether they have children
+          if (nodeA.children.size > 0 && nodeB.children.size === 0) return -1;
+          if (nodeA.children.size === 0 && nodeB.children.size > 0) return 1;
 
           // Check if the current node's id exists in orderJson
           const order = orderJson[getNodeIdFromPath(node.id)];
-
           if (order) {
-            const indexA = order.indexOf(getNodeIdFromPath(nodeA.id));
-            const indexB = order.indexOf(getNodeIdFromPath(nodeB.id));
+            const idA = getNodeIdFromPath(nodeAPath);
+            const idB = getNodeIdFromPath(nodeBPath);
+            const indexA = order.indexOf(idA);
+            const indexB = order.indexOf(idB);
 
-            // Nodes not in the order array are placed at the end
-            const posA = indexA !== -1 ? indexA : Number.MAX_SAFE_INTEGER;
-            const posB = indexB !== -1 ? indexB : Number.MAX_SAFE_INTEGER;
+            // Both nodes are in the order array
+            if (indexA !== -1 && indexB !== -1) {
+              return indexA - indexB;
+            }
 
-            // Sort based on the defined order first
-            if (posA !== posB) {
-              return posA - posB;
+            // Only nodeA is in the order array
+            if (indexA !== -1) {
+              return -1;
+            }
+
+            // Only nodeB is in the order array
+            if (indexB !== -1) {
+              return 1;
             }
           }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,8 @@
 export const SCKAN_JSON_URL =
   'https://raw.githubusercontent.com/smtifahim/SCKAN-Apps/master/sckan-explorer/json/a-b-via-c-2.json';
+
+export const SCKAN_ORDER_JSON_URL =
+  'https://raw.githubusercontent.com/MetaCell/sckan-explorer/feature/order/public/order.json';
 export const SCKAN_MAJOR_NERVES_JSON_URL =
   'https://raw.githubusercontent.com/smtifahim/SCKAN-Apps/master/sckan-explorer/json/major-nerves.json';
 


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/ESCKAN-60

- Adds example json file [here](https://github.com/MetaCell/sckan-explorer/blob/feature/order/public/order.json). This is the json file currently in use to order but we should change to one stored by the customer (or at least point to the develop / master) version of our repo
- Adds fetch order json to application startup
- Updates hierarchical service to sort the nodes according to the following logic::

1. Nodes with children are sorted before nodes without children.
2. If both nodes are in the orderJson, they are sorted based on their specified order.
3. If only one of the nodes is in the orderJson, it is sorted before the node that is not mentioned.
4. Nodes not mentioned in the orderJson are sorted naturally.


before:
![image](https://github.com/MetaCell/sckan-explorer/assets/19196034/53096cf4-83f4-42c8-9385-1bdad03861d5)

after:
![image](https://github.com/MetaCell/sckan-explorer/assets/19196034/3317c4fe-656d-48e8-9779-7ed033d9784a)
