### PR TITLE
ESCKAN-72 Modify heatmap expanded hierarchy

### DIFF
--- a/src/components/common/Heatmap.tsx
+++ b/src/components/common/Heatmap.tsx
@@ -410,9 +410,7 @@ const HeatmapGrid: FC<HeatmapGridProps> = ({
                     return {
                       ...commonStyles,
                       cursor: 'not-allowed',
-                      borderWidth: isSelectedCell ? '0.125rem' : '0.0625rem',
-                      borderColor: isSelectedCell ? '#8300BF' : gray100A,
-                      background: gray100A,
+                      opacity: 0,
                     };
                   } else if (secondary) {
                     // to show another heatmap, can be changed when data is added
@@ -445,9 +443,7 @@ const HeatmapGrid: FC<HeatmapGridProps> = ({
                 cellRender={(value: number, xLabel: string, yLabel: string) => {
                   const xIndex = xLabelToIndex[xLabel];
                   const yIndex = yLabelToIndex[yLabel];
-                  if (yAxisData.expanded[yIndex]) {
-                    return <></>;
-                  }
+
                   return (
                     <HeatmapTooltip
                       x={xLabel}
@@ -456,6 +452,7 @@ const HeatmapGrid: FC<HeatmapGridProps> = ({
                       rows={
                         secondary ? getTooltipRows(xIndex, yIndex) : undefined
                       }
+                      yExpanded={yAxisData.expanded[yIndex]}
                     />
                   );
                 }}

--- a/src/components/common/Heatmap.tsx
+++ b/src/components/common/Heatmap.tsx
@@ -443,7 +443,6 @@ const HeatmapGrid: FC<HeatmapGridProps> = ({
                 cellRender={(value: number, xLabel: string, yLabel: string) => {
                   const xIndex = xLabelToIndex[xLabel];
                   const yIndex = yLabelToIndex[yLabel];
-
                   return (
                     <HeatmapTooltip
                       x={xLabel}

--- a/src/components/common/HeatmapTooltip.tsx
+++ b/src/components/common/HeatmapTooltip.tsx
@@ -14,6 +14,7 @@ interface HeatmapTooltipProps {
   y: string;
   connections: number;
   rows?: HeatmapTooltipRow[];
+  yExpanded: boolean;
 }
 
 const commonHeadingStyles = {
@@ -35,7 +36,23 @@ const HeatmapTooltip: FC<HeatmapTooltipProps> = ({
   y,
   connections,
   rows,
+  yExpanded,
 }) => {
+  if (yExpanded) {
+    return (
+      <Tooltip
+        placement="right"
+        title={
+          <Typography sx={commonTextStyles}>
+            Explore connections in expanded child elements
+          </Typography>
+        }
+      >
+        <Box sx={{ opacity: 0 }}></Box>
+      </Tooltip>
+    );
+  }
+
   const hasRows = rows && rows.length > 0;
 
   if (connections === 0) {


### PR DESCRIPTION
Expanded row of the heatmap is now hidden with tooltip for hinting to explore the expanded child elements.

https://github.com/user-attachments/assets/8c3b5d06-1e71-47dc-a0fb-9b0dad8af9a6

