### PR TITLE
ESCKAN-73 Add population counter

### DIFF
--- a/src/components/ConnectivityGrid.tsx
+++ b/src/components/ConnectivityGrid.tsx
@@ -13,6 +13,7 @@ import {
   filterConnectionsMap,
   getNonEmptyColumns,
   filterYAxis,
+  filterKnowledgeStatements,
 } from '../services/heatmapService.ts';
 import FiltersDropdowns from './FiltersDropdowns.tsx';
 import { HierarchicalItem } from './common/Types.ts';
@@ -147,7 +148,14 @@ function ConnectivityGrid() {
 
   const isLoading = yAxis.length == 0;
 
-  const totalPopulationCount = 253; // TODO: calculate
+  const totalPopulationCount = useMemo(() => {
+    const filteredStatements = filterKnowledgeStatements(
+      knowledgeStatements,
+      hierarchicalNodes,
+      filters,
+    );
+    return Object.keys(filteredStatements).length;
+  }, [knowledgeStatements, hierarchicalNodes, filters]);
 
   return isLoading ? (
     <Loader />

--- a/src/components/ConnectivityGrid.tsx
+++ b/src/components/ConnectivityGrid.tsx
@@ -26,6 +26,7 @@ const {
   gray100,
   primaryPurple600,
   gray400,
+  gray600A,
 } = vars;
 
 function ConnectivityGrid() {
@@ -146,6 +147,8 @@ function ConnectivityGrid() {
 
   const isLoading = yAxis.length == 0;
 
+  const totalPopulationCount = 253; // TODO: calculate
+
   return isLoading ? (
     <Loader />
   ) : (
@@ -157,9 +160,19 @@ function ConnectivityGrid() {
       display="flex"
       flexDirection="column"
     >
-      <Box pb={2.5}>
+      <Box display="flex" justifyContent="space-between" pb={2.5}>
         <Typography variant="h6" sx={{ fontWeight: 400 }}>
           Connection Origin to End Organ
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: '0.875rem',
+            fontWeight: 500,
+            lineHeight: '1.25rem',
+            color: gray600A,
+          }}
+        >
+          {totalPopulationCount} populations
         </Typography>
       </Box>
 


### PR DESCRIPTION
The population filter (top-right of the left side widget) needs to be added. Beware of the fact that the counter needs to be updated if the filters are active.

[Figma design](https://www.figma.com/design/j5q1LPeH9wqX2S5TjitT40/SCKAN-Explorer-UI?node-id=1872-163563&t=htJXNUiTJblVCzLJ-1)

Current changes:
- population counter add in connectivity grid, reusing the already implemented `filterKnowledgeStatements` function.

> [!WARNING]  
> `filterKnowledgeStatements` does NOT account for the `EndOrgan` filter. Don't know if it is expected or not.


https://github.com/user-attachments/assets/59b175c3-a158-428f-b57d-53d979a606b9

