### PR TITLE
ESCKAN-77 Add tooltip for the filters in the left-side widget

### DIFF
--- a/src/components/common/CustomFilterDropdown.tsx
+++ b/src/components/common/CustomFilterDropdown.tsx
@@ -251,7 +251,9 @@ export default function CustomEntitiesDropdown({
             ref={dropdownButtonRef}
           >
             {selectedOptions.length === 0 ? (
-              <Typography sx={styles.placeholder}>{placeholder}</Typography>
+              <Tooltip body={placeholder} arrow placement="top">
+                <Typography sx={styles.placeholder}>{placeholder}</Typography>
+              </Tooltip>
             ) : (
               <Box gap={0} display="flex" flexWrap="wrap" alignItems="center">
                 {updatedSelectedOptions?.map((item: Option) => {
@@ -493,44 +495,35 @@ export default function CustomEntitiesDropdown({
                       </ListSubheader>
                       <ul>
                         {autocompleteOptions.map((option: Option) => (
-                          <Tooltip
-                            body={option.label}
-                            heading="label"
-                            arrow
-                            placement="right"
+                          <li
+                            key={option.id}
+                            onClick={() => handleOptionSelection(option)}
+                            className={
+                              isOptionSelected(option) ? 'selected' : ''
+                            }
                           >
-                            <li
-                              key={option.id}
-                              onClick={() => handleOptionSelection(option)}
-                              className={
-                                isOptionSelected(option) ? 'selected' : ''
-                              }
+                            <Checkbox
+                              disableRipple
+                              icon={<UncheckedItemIcon fontSize="small" />}
+                              checkedIcon={<CheckedItemIcon fontSize="small" />}
+                              checked={isOptionSelected(option)}
+                            />
+                            <Typography
+                              sx={{
+                                width: 1,
+                                height: 1,
+                                padding: '0.625rem',
+                              }}
                             >
-                              <Checkbox
-                                disableRipple
-                                icon={<UncheckedItemIcon fontSize="small" />}
-                                checkedIcon={
-                                  <CheckedItemIcon fontSize="small" />
-                                }
-                                checked={isOptionSelected(option)}
-                              />
-                              <Typography
-                                sx={{
-                                  width: 1,
-                                  height: 1,
-                                  padding: '0.625rem',
-                                }}
-                              >
-                                {option?.label?.length > 100
-                                  ? option?.label.slice(0, 100) + '...'
-                                  : option?.label}
-                              </Typography>
+                              {option?.label?.length > 100
+                                ? option?.label.slice(0, 100) + '...'
+                                : option?.label}
+                            </Typography>
 
-                              {/* <Typography whiteSpace="nowrap" variant="body2">
+                            {/* <Typography whiteSpace="nowrap" variant="body2">
                               {option?.id}
                             </Typography> */}
-                            </li>
-                          </Tooltip>
+                          </li>
                         ))}
                       </ul>
                     </Box>

--- a/src/components/common/CustomFilterDropdown.tsx
+++ b/src/components/common/CustomFilterDropdown.tsx
@@ -509,17 +509,12 @@ export default function CustomEntitiesDropdown({
                               checked={isOptionSelected(option)}
                             />
                             <Typography
-                              sx={{
-                                width: 1,
-                                height: 1,
-                                padding: '0.625rem',
-                              }}
+                              sx={{ width: 1, height: 1, padding: '0.625rem' }}
                             >
                               {option?.label?.length > 100
                                 ? option?.label.slice(0, 100) + '...'
                                 : option?.label}
                             </Typography>
-
                             {/* <Typography whiteSpace="nowrap" variant="body2">
                               {option?.id}
                             </Typography> */}

--- a/src/components/common/CustomFilterDropdown.tsx
+++ b/src/components/common/CustomFilterDropdown.tsx
@@ -4,7 +4,6 @@ import {
   ClickAwayListener,
   InputAdornment,
   Popper,
-  Tooltip,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import {
@@ -22,6 +21,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { vars } from '../../theme/variables';
 import { Option } from './Types.ts';
+import Tooltip from './Tooltip.tsx';
 
 const {
   gray100,
@@ -256,7 +256,7 @@ export default function CustomEntitiesDropdown({
               <Box gap={0} display="flex" flexWrap="wrap" alignItems="center">
                 {updatedSelectedOptions?.map((item: Option) => {
                   return (
-                    <Tooltip title={item?.label} placement="top" arrow>
+                    <Tooltip body={item?.label} placement="top" arrow>
                       <Chip
                         key={item?.id}
                         sx={styles.chip}
@@ -493,30 +493,44 @@ export default function CustomEntitiesDropdown({
                       </ListSubheader>
                       <ul>
                         {autocompleteOptions.map((option: Option) => (
-                          <li
-                            key={option.id}
-                            onClick={() => handleOptionSelection(option)}
-                            className={
-                              isOptionSelected(option) ? 'selected' : ''
-                            }
+                          <Tooltip
+                            body={option.label}
+                            heading="label"
+                            arrow
+                            placement="right"
                           >
-                            <Checkbox
-                              disableRipple
-                              icon={<UncheckedItemIcon fontSize="small" />}
-                              checkedIcon={<CheckedItemIcon fontSize="small" />}
-                              checked={isOptionSelected(option)}
-                            />
-                            <Typography
-                              sx={{ width: 1, height: 1, padding: '0.625rem' }}
+                            <li
+                              key={option.id}
+                              onClick={() => handleOptionSelection(option)}
+                              className={
+                                isOptionSelected(option) ? 'selected' : ''
+                              }
                             >
-                              {option?.label?.length > 100
-                                ? option?.label.slice(0, 100) + '...'
-                                : option?.label}
-                            </Typography>
-                            {/* <Typography whiteSpace="nowrap" variant="body2">
+                              <Checkbox
+                                disableRipple
+                                icon={<UncheckedItemIcon fontSize="small" />}
+                                checkedIcon={
+                                  <CheckedItemIcon fontSize="small" />
+                                }
+                                checked={isOptionSelected(option)}
+                              />
+                              <Typography
+                                sx={{
+                                  width: 1,
+                                  height: 1,
+                                  padding: '0.625rem',
+                                }}
+                              >
+                                {option?.label?.length > 100
+                                  ? option?.label.slice(0, 100) + '...'
+                                  : option?.label}
+                              </Typography>
+
+                              {/* <Typography whiteSpace="nowrap" variant="body2">
                               {option?.id}
                             </Typography> */}
-                          </li>
+                            </li>
+                          </Tooltip>
                         ))}
                       </ul>
                     </Box>

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -1,0 +1,64 @@
+import { FC, ReactElement } from 'react';
+import { vars } from '../../theme/variables';
+import { Box, Tooltip as MaterialTooltip, Typography } from '@mui/material';
+import { type TooltipProps as MaterialTooltipProps } from '@mui/material';
+const { gray25, gray300 } = vars;
+
+interface TooltipProps extends Omit<MaterialTooltipProps, 'title'> {
+  heading?: string;
+  body: string | React.ReactNode;
+  minWidth?: number;
+}
+
+const commonHeadingStyles = {
+  fontSize: '0.75rem',
+  fontWeight: 500,
+  lineHeight: '1.125rem',
+  color: gray300,
+};
+
+export const commonTextStyles = {
+  fontSize: '0.75rem',
+  fontWeight: 600,
+  lineHeight: '1.125rem',
+  color: gray25,
+};
+
+const Tooltip: FC<TooltipProps> = ({
+  heading,
+  body,
+  minWidth,
+  children,
+  ...tooltipProps
+}) => {
+  const isContentString = typeof body === 'string';
+
+  return (
+    <MaterialTooltip
+      {...tooltipProps}
+      title={
+        <Box minWidth={minWidth}>
+          <Typography
+            sx={{
+              ...commonHeadingStyles,
+              marginBottom: '0.125rem',
+            }}
+          >
+            {heading}
+          </Typography>
+          {isContentString ? (
+            <Typography sx={{ ...commonTextStyles, marginTop: '0.125rem' }}>
+              {body}
+            </Typography>
+          ) : (
+            <>{body}</>
+          )}
+        </Box>
+      }
+    >
+      {children}
+    </MaterialTooltip>
+  );
+};
+
+export default Tooltip;

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement } from 'react';
+import { FC } from 'react';
 import { vars } from '../../theme/variables';
 import { Box, Tooltip as MaterialTooltip, Typography } from '@mui/material';
 import { type TooltipProps as MaterialTooltipProps } from '@mui/material';
@@ -17,7 +17,7 @@ const commonHeadingStyles = {
   color: gray300,
 };
 
-export const commonTextStyles = {
+const commonTextStyles = {
   fontSize: '0.75rem',
   fontWeight: 600,
   lineHeight: '1.125rem',


### PR DESCRIPTION
Current changes:

1. Implemented custom Tooltip component (`ON APPROVED`: replace existing Material UI tooltips across codebase were it makes sense)
2. Added tooltip to filter dropdown. Content of the tooltip still to be defined.

https://github.com/user-attachments/assets/e166f2e0-2e32-4fd9-a5c9-b33abd1532d9
