### PR TITLE
ESCKAN-75 Fix nerves filtering

### DIFF
--- a/src/context/DataContextProvider.tsx
+++ b/src/context/DataContextProvider.tsx
@@ -1,4 +1,10 @@
-import { PropsWithChildren, useEffect, useMemo, useState } from 'react';
+import {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { DataContext, Filters, ConnectionSummary } from './DataContext';
 import {
   HierarchicalNode,
@@ -68,27 +74,48 @@ export const DataContextProvider = ({
     return colorMap;
   }, [phenotypes]);
 
-  const updateSelectedConnectionSummary = (
-    summary:
-      | Omit<ConnectionSummary, 'filteredKnowledgeStatements'>
-      | ConnectionSummary
-      | null,
-    filters: Filters,
-    hierarchicalNodes: Record<string, HierarchicalNode>,
-  ) => {
-    if (summary) {
-      const filteredKnowledgeStatements = filterKnowledgeStatements(
-        summary.connections,
-        hierarchicalNodes,
-        filters,
-      );
-      return {
-        ...summary,
-        filteredKnowledgeStatements,
-      };
-    }
-    return null;
-  };
+  const updateSelectedConnectionSummary = useCallback(
+    (
+      summary:
+        | Omit<ConnectionSummary, 'filteredKnowledgeStatements'>
+        | ConnectionSummary
+        | null,
+      filters: Filters,
+      hierarchicalNodes: Record<string, HierarchicalNode>,
+    ) => {
+      if (summary) {
+        let filteredKnowledgeStatements = filterKnowledgeStatements(
+          summary.connections,
+          hierarchicalNodes,
+          filters,
+        );
+
+        filteredKnowledgeStatements = Object.fromEntries(
+          Object.entries(filteredKnowledgeStatements).map(
+            ([key, statement]) => [
+              key,
+              {
+                ...statement,
+                vias: statement.vias.map((via) => ({
+                  ...via,
+                  anatomical_entities: via.anatomical_entities.filter(
+                    (entity) => majorNerves.has(entity.id),
+                  ),
+                })),
+              },
+            ],
+          ),
+        );
+
+        return {
+          ...summary,
+          filteredKnowledgeStatements,
+        };
+      }
+      return null;
+    },
+    [majorNerves],
+  );
 
   const handleSetSelectedConnectionSummary = (
     summary: Omit<ConnectionSummary, 'filteredKnowledgeStatements'> | null,
@@ -105,7 +132,7 @@ export const DataContextProvider = ({
     setSelectedConnectionSummary((prevSummary) =>
       updateSelectedConnectionSummary(prevSummary, filters, hierarchicalNodes),
     );
-  }, [filters, hierarchicalNodes]);
+  }, [filters, hierarchicalNodes, updateSelectedConnectionSummary]);
 
   const dataContextValue = {
     filters,


### PR DESCRIPTION
Current changes:

- Each time we select a connection, in the context provider, it filters out anatomical entities that are not present in the neurons file provided by the client. This is propagated through the app, reflecting both in the PDF download and connections summary.

Another solution for this can be seen in https://github.com/MetaCell/sckan-explorer/compare/develop...feature/ESCKAN-75.