### PR TITLE
Fix typescript build linting errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,12 +160,14 @@ const App = () => {
                       />
                     ) : (
                       <DataContextProvider
-                        majorNerves={majorNerves}
+                        majorNerves={
+                          majorNerves ? majorNerves : new Set<string>()
+                        }
                         hierarchicalNodes={hierarchicalNodes}
                         organs={organs}
                         knowledgeStatements={knowledgeStatements}
                       >
-                        <LayoutComponent />
+                        {LayoutComponent && <LayoutComponent />}
                       </DataContextProvider>
                     )
                   }

--- a/src/components/ConnectivityGrid.tsx
+++ b/src/components/ConnectivityGrid.tsx
@@ -17,7 +17,7 @@ import {
 import FiltersDropdowns from './FiltersDropdowns.tsx';
 import { HierarchicalItem } from './common/Types.ts';
 import { Organ } from '../models/explorer.ts';
-import Loader from './common/Loader.tsx';
+import LoaderSpinner from './common/LoaderSpinner.tsx';
 
 const {
   gray500,
@@ -147,7 +147,7 @@ function ConnectivityGrid() {
   const isLoading = yAxis.length == 0;
 
   return isLoading ? (
-    <Loader />
+    <LoaderSpinner />
   ) : (
     <Box
       minHeight="100%"

--- a/src/components/SummaryPage.tsx
+++ b/src/components/SummaryPage.tsx
@@ -6,7 +6,7 @@ import { Detail } from './summaryPage/Detail.tsx';
 import { Section, SubSection } from './summaryPage/Section.tsx';
 import { TabPanel } from './summaryPage/TabPanel.tsx';
 import InfoTab from './summaryPage/InfoTab.tsx';
-import Loader from './common/Loader.tsx';
+import LoaderSpinner from './common/LoaderSpinner.tsx';
 import {
   SCKAN_DATABASE_SUMMARY_URL_LATEST,
   SCKAN_DATABASE_SUMMARY_URL_PREVIOUS,
@@ -252,7 +252,7 @@ const SummaryPage = () => {
   if (!loaded)
     return (
       <Box display="flex" justifyContent="center" alignItems="center" width={1}>
-        <Loader />
+        <LoaderSpinner />
       </Box>
     );
   return (

--- a/src/components/common/LoaderSpinner.tsx
+++ b/src/components/common/LoaderSpinner.tsx
@@ -1,0 +1,23 @@
+import { Box, CircularProgress } from '@mui/material';
+
+interface LoaderSpinnerProps {
+  text?: string;
+}
+
+const LoaderSpinner: React.FC<LoaderSpinnerProps> = ({ text }) => {
+  return (
+    <Box
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      height="100vh"
+      width="100vw"
+      flexDirection={'column'}
+    >
+      <CircularProgress id="circular_loader" size={60} />
+      {text && <div id="loader_text">{text}</div>}
+    </Box>
+  );
+};
+
+export default LoaderSpinner;


### PR DESCRIPTION
The linter specified by the `package.json`, `lint` target, doesn't seem to catch things with the same rules as when building the application, so the build was breaking.

Changes:

1. Components depending on the old loader component have it available as `LoaderSpinner`
2. Added missing `undefined` verifications