### PR TITLE
Feature/esckan-81 - Update pdf and connection summary

### DIFF
--- a/applications/sckanner/frontend/src/components/connections/SummaryDetails.tsx
+++ b/applications/sckanner/frontend/src/components/connections/SummaryDetails.tsx
@@ -144,7 +144,7 @@ const SummaryDetails = ({
             Connection summary
           </Typography>
           <Typography variant="body1" color={gray500}>
-            {connectionDetails?.knowledge_statement || '-'}
+            {connectionDetails?.statement_preview || '-'}
           </Typography>
           {phenotype && <CommonChip label={phenotype} variant="outlined" />}
           <CommonAccordion

--- a/applications/sckanner/frontend/src/services/pdfService.ts
+++ b/applications/sckanner/frontend/src/services/pdfService.ts
@@ -242,12 +242,42 @@ export const getPDFContent = (
       margin: [0, 30, 0, 10],
     },
     {
-      style: 'tableExample',
-      table: {
-        body: connectivityMatrix,
-      },
-      fontSize:
-        filteredColumns.length > 13 ? 6 : filteredColumns.length > 6 ? 8 : 10,
+      text: 'End organ → ',
+      style: 'subheader',
+      bold: true,
+      margin: [80, 10, 0, 15],
+    },
+    {
+      columns: [
+        {
+          stack: [
+            {
+              text: 'Origin',
+              style: 'subheader',
+              bold: true,
+              margin: [0, 30, 10, 0],
+              width: 40
+            },
+            {
+              text: '↓',
+              style: 'subheader',
+              alignment: 'center',
+              bold: true,
+              margin: [0, 10, 10, 0],
+              width: 40
+            }
+          ],
+          width: 50
+        },
+        {
+          style: 'tableExample',
+          table: {
+            body: connectivityMatrix,
+          },
+          fontSize:
+            filteredColumns.length > 13 ? 6 : filteredColumns.length > 6 ? 8 : 10,
+        },
+      ],
     },
   ];
 

--- a/applications/sckanner/frontend/src/services/pdfService.ts
+++ b/applications/sckanner/frontend/src/services/pdfService.ts
@@ -74,6 +74,7 @@ export const getPDFContent = (
     entitiesJourney,
     connectionDetails,
   } = pdfRequirement;
+  const distinctNeuronPopulations = connectionDetails.length;
   // SECTION 1 - Result summary
   const resultSummary: PDFMAKEContent = [
     {
@@ -117,7 +118,7 @@ export const getPDFContent = (
       fontSize: 16,
     },
     {
-      text: `This information comes from ${numOfConnections} connections. `,
+      text: `This information comes from ${numOfConnections} connections extracted from ${distinctNeuronPopulations} distinct neuron populations. `,
       style: 'paragraph',
       margin: [0, 15, 0, 0],
     },
@@ -146,7 +147,7 @@ export const getPDFContent = (
   // SECTION 2 - Connection details
   const connectionDetailsContent: PDFMAKEContent = [
     {
-      text: 'Connection details:',
+      text: 'Connection details for each distinct neuron population:',
       style: 'subheader',
       bold: true,
       margin: [0, 30, 0, 0],

--- a/applications/sckanner/frontend/src/services/pdfService.ts
+++ b/applications/sckanner/frontend/src/services/pdfService.ts
@@ -26,7 +26,7 @@ type pdfRequirementType = {
 };
 
 type ConnectionDetailType = {
-  'Knowledge Statement'?: string;
+  'Statement Preview'?: string;
   'Connection Id'?: string;
   Species?: string;
   Sex?: string;
@@ -164,14 +164,6 @@ export const getPDFContent = (
 
   connectionDetails.map((detail) => {
     for (const [key, value] of Object.entries(detail)) {
-      if (key === 'Knowledge Statement') {
-        connectionDetailsContent.push({
-          text: `${value}`,
-          style: 'paragraph',
-          margin: [0, 10, 0, 0],
-        });
-        continue;
-      }
       connectionDetailsContent.push({
         text: [{ text: `${key}`, bold: true }, { text: `: ${value}` }],
         margin: [0, 10, 0, 0],
@@ -327,7 +319,7 @@ export const generatePDFService = (
     ? Object.keys(filteredKnowledgeStatements).map((ksid) => {
         const ks = filteredKnowledgeStatements[ksid];
         const details: ConnectionDetailType = {
-          'Knowledge Statement': ks.knowledge_statement || '-',
+          'Statement Preview': ks.statement_preview || '-',
           'Connection Id': ks.id || '-',
           Species: ks.species.map((specie) => specie.name).join(', ') || '-',
           Sex: ks.sex.name || '-',


### PR DESCRIPTION
Jira link - [ESCKAN-81](https://metacell.atlassian.net/browse/ESCKAN-81)

1. Change the UI to show `statement preview` instead of `knowledge statement`
![image](https://github.com/user-attachments/assets/f91b7fbb-8bf6-41d4-8580-e4ed453ccfa5)

2. Again in PDF exported - show `statement preview` instead of `knowledge statement`
3. Changes to show distinct neuron population
4. Change the table view to show the labels, it looks as below image and demo pdf file

![Screenshot 2024-12-10 175807](https://github.com/user-attachments/assets/e2e7431a-f3a2-4e45-aa50-84cffbdb8cea)

![Screenshot 2024-12-10 180038](https://github.com/user-attachments/assets/fed55548-b4a5-4fa8-8eb0-2bd324b24bb7)


------
note - that the downloaded unique population count is based on the filteredKS - i.e. similar to what we have in the heatmap at that point. 

------




demo file 
[file (25).pdf](https://github.com/user-attachments/files/18079525/file.25.pdf)


[ESCKAN-81]: https://metacell.atlassian.net/browse/ESCKAN-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ