### PR TITLE
Feature/esckan-83 - Format CSV 

### DIFF
--- a/applications/sckanner/frontend/src/models/explorer.ts
+++ b/applications/sckanner/frontend/src/models/explorer.ts
@@ -270,7 +270,7 @@ export interface KnowledgeStatement {
 
   /**
    *
-   * @type {Array<string>}
+   * @type {Sex}
    * @memberof KnowledgeStatement
    */
   sex: Sex;

--- a/applications/sckanner/frontend/src/services/csvService.ts
+++ b/applications/sckanner/frontend/src/services/csvService.ts
@@ -187,32 +187,39 @@ export const generateJourneyCsvService = (
   ];
 
   const headers = [
+    'Connectivity Result',
     'ID',
-    'Connection summary',
+    'Connection summary/Knowledge Statement',
     'Species',
+    'Species ID',
     'Sex',
-    'Origins (Names)',
-    'Origins (IDs)',
-    'Destinations (Names)',
-    'Destinations (IDs)',
+    'Sex ID',
+    'Origin',
+    'Origin ID',
+    'Destination',
+    'Destination IDs',
     'Journey',
+    'Via ID',
     'Phenotype',
     'Laterality',
-    'Forward Connections',
-    'Synapses on',
-    'Target Organ',
+    'Forward Connection(s)',
+    'Synapses on (between first population and second)',
+    'TARGET Organ (final organ after forward connections)',
     'Provenances',
   ];
 
   const rows = [...metadata, headers];
 
   Object.values(data).forEach((entry) => {
-    entry.journey.forEach((journey) => {
+    entry.journey.forEach((journey, index) => {
       const row = [
+        index + 1,
         entry.id,
         entry.knowledge_statement,
         entry.species.map((s) => s.name).join('; '),
+        entry.species.map((s) => s.id).join('; '),
         entry.sex.name,
+        entry.sex.id,
         [...new Set(entry.origins.map((o) => o.name))].join('; '),
         [...new Set(entry.origins.map((o) => o.id))].join('; '),
         [
@@ -230,6 +237,13 @@ export const generateJourneyCsvService = (
           ),
         ].join('; '),
         journey,
+        [
+          ...new Set(
+            entry.vias.flatMap((via) =>
+              via.anatomical_entities.map((ae) => ae.id),
+            ),
+          ),
+        ].join('; '),
         entry.phenotype,
         entry.laterality,
         entry.forwardConnections.map((fc) => fc.reference_uri).join('; '),

--- a/applications/sckanner/frontend/src/services/csvService.ts
+++ b/applications/sckanner/frontend/src/services/csvService.ts
@@ -3,6 +3,7 @@
 import { KnowledgeStatement } from '../models/explorer';
 import { Filters } from '../context/DataContext';
 import { NEURONDM_VERSION, COMPOSER_VERSION } from '../settings';
+import { KsRecord } from '../components/common/Types';
 
 type csvData = {
   [key: string]: KnowledgeStatement;
@@ -218,8 +219,8 @@ export const generateJourneyCsvService = (
         entry.knowledge_statement,
         entry.species.map((s) => s.name).join('; '),
         entry.species.map((s) => s.id).join('; '),
-        entry.sex.name,
-        entry.sex.id,
+        entry.sex.name || '',
+        entry.sex.id || '',
         [...new Set(entry.origins.map((o) => o.name))].join('; '),
         [...new Set(entry.origins.map((o) => o.id))].join('; '),
         [

--- a/applications/sckanner/frontend/src/services/csvService.ts
+++ b/applications/sckanner/frontend/src/services/csvService.ts
@@ -220,7 +220,7 @@ export const generateJourneyCsvService = (
         entry.species.map((s) => s.name).join('; '),
         entry.species.map((s) => s.id).join('; '),
         entry.sex.name || '',
-        entry.sex.id || '',
+        entry.sex.ontology_uri || '',
         [...new Set(entry.origins.map((o) => o.name))].join('; '),
         [...new Set(entry.origins.map((o) => o.id))].join('; '),
         [

--- a/applications/sckanner/frontend/src/services/mappers.ts
+++ b/applications/sckanner/frontend/src/services/mappers.ts
@@ -104,7 +104,7 @@ export function mapApiResponseToKnowledgeStatements(
     laterality: ks.laterality || '',
     projection: ks.projection || '',
     circuit_type: ks.circuit_type || '',
-    sex: ks.sex || [],
+    sex: ks.sex || {},
     statement_preview: ks.statement_preview || '',
   }));
 }


### PR DESCRIPTION
Jira link - https://metacell.atlassian.net/browse/ESCKAN-83


Fixes:
- show empty rows instead of undefined - when `sex` is not available. (for sex.name and sex.ontology_uri)
![image](https://github.com/user-attachments/assets/c6ba212d-f0a8-41ce-8793-27a86d3f5c5c)


Add the column headers - similar to the [reference here](https://docs.google.com/spreadsheets/d/1yl3VoGyFzjl8VZaGLaz3bUYcKYkynxlX/edit?gid=1008024949#gid=1008024949)


Columns added:
- Connectivity Result 
- ViaID column.
- Species ID (ontology_uri)
- Sex ID (ontology_uri)


I noticed a column - ID is not present in the [reference here](https://docs.google.com/spreadsheets/d/1yl3VoGyFzjl8VZaGLaz3bUYcKYkynxlX/edit?gid=1008024949#gid=1008024949). I assume that is accidental and it should still stay in the export. Let me know if we need to remove this @ddelpiano 


