### PR TITLE
Feature/esckan-91 - Click here for tutorials text change

### DIFF
--- a/applications/sckanner/frontend/src/components/connections/SummaryInstructions.tsx
+++ b/applications/sckanner/frontend/src/components/connections/SummaryInstructions.tsx
@@ -101,7 +101,7 @@ const SummaryInstructions = () => {
             style={{
               fontSize: '0.875rem',
               fontFamily: 'Asap, sans-serif',
-              marginBottom: '3rem',
+              marginBottom: '2rem',
             }}
           ></p>
           <a
@@ -113,11 +113,12 @@ const SummaryInstructions = () => {
               style={{
                 cursor: 'pointer',
                 fontSize: '0.875rem',
+                fontWeight: 600,
                 fontFamily: 'Asap, sans-serif',
               }}
             >
               {' '}
-              Click here to check more information about SCKANNER.
+              Click here for additional documentation and tutorials.
             </p>
           </a>
         </Typography>


### PR DESCRIPTION
Jira link - https://metacell.atlassian.net/browse/ESCKAN-91


Request:

> can you change the text in SCKANNER from “[Click here to check more information about SCKANNER.](https://docs.sparc.science/docs/sckanner)” to “Click here for additional documentation and tutorials.” and maybe make it a bit bigger-or put it at the top of that page.


@ddelpiano - The text has been changed. But should i also move it to the top?

![image](https://github.com/user-attachments/assets/0cff5a41-7386-4bc3-8839-99798b471b09)
