### PR TITLE
Feature/esckan-86: update population count on End Organ filtering

### DIFF
--- a/applications/sckanner/frontend/src/components/ConnectivityGrid.tsx
+++ b/applications/sckanner/frontend/src/components/ConnectivityGrid.tsx
@@ -155,6 +155,7 @@ function ConnectivityGrid() {
       knowledgeStatements,
       hierarchicalNodes,
       organizedFilters,
+      organs
     );
     return Object.keys(filteredStatements).length;
   }, [knowledgeStatements, hierarchicalNodes, organizedFilters]);

--- a/applications/sckanner/frontend/src/context/DataContextProvider.tsx
+++ b/applications/sckanner/frontend/src/context/DataContextProvider.tsx
@@ -88,6 +88,7 @@ export const DataContextProvider = ({
           summary.connections,
           hierarchicalNodes,
           filters,
+          organs,
         );
 
         filteredKnowledgeStatements = Object.fromEntries(

--- a/applications/sckanner/frontend/src/services/heatmapService.ts
+++ b/applications/sckanner/frontend/src/services/heatmapService.ts
@@ -209,7 +209,7 @@ export function filterOrgans(
   );
 }
 
-export function extractOrganKeys(organs: Record<string, Organ>) {
+export function extractEndOrganKeys(organs: Record<string, Organ>) {
   const organKeys: string[] = [];
   Object.values(organs).forEach((organ) => {
     organKeys.push(organ.id); // Add the organ's own ID
@@ -256,7 +256,7 @@ export function filterKnowledgeStatements(
     ) || [];
 
   const organs = filterOrgans(allOrgans, filters.EndOrgan);
-  const organKeysSelectedFromFilters = extractOrganKeys(organs)
+  const organKeysSelectedFromFilters = extractEndOrganKeys(organs)
 
   return Object.entries(knowledgeStatements).reduce(
     (filtered, [id, ks]) => {

--- a/applications/sckanner/frontend/src/services/heatmapService.ts
+++ b/applications/sckanner/frontend/src/services/heatmapService.ts
@@ -60,6 +60,7 @@ export function calculateConnections(
     allKnowledgeStatements,
     hierarchicalNodes,
     filters,
+    allOrgans,
   );
   const organs = filterOrgans(allOrgans, filters.EndOrgan);
 
@@ -208,10 +209,24 @@ export function filterOrgans(
   );
 }
 
+export function extractOrganKeys(organs: Record<string, Organ>) {
+  const organKeys: string[] = [];
+  Object.values(organs).forEach((organ) => {
+    organKeys.push(organ.id); // Add the organ's own ID
+    if (organ.children instanceof Map) {
+      organ.children.forEach((childOrgan) => {
+        organKeys.push(childOrgan.id); // Add each child's ID
+      });
+    }
+  });
+  return organKeys;
+}
+
 export function filterKnowledgeStatements(
   knowledgeStatements: Record<string, KnowledgeStatement>,
   hierarchicalNodes: Record<string, HierarchicalNode>,
   filters: Filters,
+  allOrgans: Record<string, Organ>
 ): Record<string, KnowledgeStatement> {
 
   const phenotypeIds = filters.Phenotype.map((option) => option.id);
@@ -240,6 +255,9 @@ export function filterKnowledgeStatements(
         : getLeafDescendants(option.id, hierarchicalNodes),
     ) || [];
 
+  const organs = filterOrgans(allOrgans, filters.EndOrgan);
+  const organKeysSelectedFromFilters = extractOrganKeys(organs)
+
   return Object.entries(knowledgeStatements).reduce(
     (filtered, [id, ks]) => {
       const phenotypeMatch =
@@ -267,13 +285,20 @@ export function filterKnowledgeStatements(
           .some((entity) => entityIds.includes(entity.id)) ||
         ks.origins?.some((origin) => entityIds.includes(origin.id));
 
+      const organMatch = filters.EndOrgan.length > 0 ? (
+        ks.destinations
+          ?.flatMap((destination) => destination.anatomical_entities)
+          .some((destination) => organKeysSelectedFromFilters.includes(destination.id))
+      ) : true;
+
       if (
         phenotypeMatch &&
         apiNATOMYMatch &&
         speciesMatch &&
         viaMatch &&
         originMatch &&
-        entityMatch
+        entityMatch &&
+        organMatch
       ) {
         filtered[id] = ks;
       }


### PR DESCRIPTION
We currently support filterKnowledgeStatements (and thus the total population count) for all the rest of the 5 filters (Origin, Species, Phenotype, Connectivity Model, Via, and Anatomical Structures). But the total population count doesn't get updated when the End Organ filter is applied. 

This PR is to support total population count updation - when the End Organ Filter (or from now onwards - any End Organs as part of Anatomical Structure) is applied. 

Approach is to get all the organ ids - from the selected filters and it's children's ids. And then check if this matches the Knowledge statement's destination anatomical entities. 


The following is an example of how the data looks like for organKeys - which we use to check in the KS's destinations. 

![image](https://github.com/user-attachments/assets/8ddd306e-1e45-4fab-98e8-ed02db765ae0)







