### PR TITLE
filtering per destination id to include also region+layer pairs

### DIFF
--- a/applications/sckanner/frontend/src/services/heatmapService.ts
+++ b/applications/sckanner/frontend/src/services/heatmapService.ts
@@ -288,7 +288,9 @@ export function filterKnowledgeStatements(
           ? ks.destinations
               ?.flatMap((destination) => destination.anatomical_entities)
               .some((destination) =>
-                organKeysSelectedFromFilters.includes(destination.id),
+                organKeysSelectedFromFilters.some((organKey) =>
+                  destination.id.includes(organKey),
+                ),
               )
           : true;
 


### PR DESCRIPTION
End organs filtering was initially designed to work on the old anatomical entities.
Since we introduced region+layer pairs this logic had to be revisited, this should fix the problem.