### PR TITLE
ESCKAN-97 - add volume for the persistent  - ingestion files - and pass shared volume mount in the argo wokflow custom task

### DIFF
--- a/applications/sckanner/backend/sckanner/services/ingestion/argo_workflow_service.py
+++ b/applications/sckanner/backend/sckanner/services/ingestion/argo_workflow_service.py
@@ -2,9 +2,17 @@ from cloudharness.workflows import operations, tasks
 from django.utils import timezone
 from sckanner.models import DataSnapshot, DataSnapshotStatus
 import logging
+from django.conf import settings
+
+from cloudharness.applications import get_current_configuration
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def get_volume_directory(current_app) -> str:
+    return f"{current_app.harness.deployment.volume.name}:{settings.MEDIA_ROOT}"
 
 
 class ArgoWorkflowService:
@@ -16,6 +24,7 @@ class ArgoWorkflowService:
         Run the ingestion workflow for the given source.
         This method is called by the Argo workflow.
         """
+        current_app = get_current_configuration()
 
         snapshot = DataSnapshot.objects.create(
             source=source,
@@ -24,6 +33,7 @@ class ArgoWorkflowService:
             timestamp=timezone.now(),
         )
         logger.info(f"Running ingestion workflow for source: {source}")
+        logger.info(f"Volume directory: {get_volume_directory(current_app)}")
         task_ingestion = tasks.CustomTask(
             "ingestion",
             image_name="sckanner",
@@ -38,6 +48,7 @@ class ArgoWorkflowService:
                 "--snapshot_id",
                 str(snapshot.id),
             ],
+            volume_mounts=[get_volume_directory(current_app)]
         )
 
         op = operations.PipelineOperation(f"sckanner-ingestion-op-", [task_ingestion])

--- a/applications/sckanner/backend/sckanner/services/ingestion/connectivity_statement_adapter.py
+++ b/applications/sckanner/backend/sckanner/services/ingestion/connectivity_statement_adapter.py
@@ -7,7 +7,10 @@ from sckanner.models import DataSnapshotStatus
 import os
 import importlib.util
 import sys
+import logging
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 class ConnectivityStatementAdapter:
 	def __init__(self, source, snapshot, reference_uri_key: str):
@@ -16,6 +19,7 @@ class ConnectivityStatementAdapter:
 		self.reference_uri_key = reference_uri_key
 
 	def extract_statements(self) -> ConnectivityStatementData:
+		logger.info(f"Extracting statements from {self.source.python_code_file_for_statements_retrival}")
 		file_path = self.source.python_code_file_for_statements_retrival
 		return self._parse_and_validate_statements(file_path)
 
@@ -45,6 +49,8 @@ class ConnectivityStatementAdapter:
 					)
 				)
 			else:
+				logger.error(f"Uploaded file {file_path} does not contain a get_statements function")
 				raise ValueError(f"Uploaded file {file_path} does not contain a get_statements function")
 		else:
+			logger.error(f"File {file_path} does not exist")
 			raise ValueError(f"File {file_path} does not exist")

--- a/applications/sckanner/deploy/values.yaml
+++ b/applications/sckanner/deploy/values.yaml
@@ -10,6 +10,12 @@ harness:
   deployment: 
     auto: true
     port: 8080
+    volume:
+      mountpath: /usr/src/app/persistent
+      name: sckanner-ingestion-files
+      auto: true
+      size: 30Mi
+      usenfs: false
   livenessProbe: {path: /api/live}
   readinessProbe: {path: /api/ready}
   secured: true


### PR DESCRIPTION
Task description:

The objective of this PR is to add a new volume - such that any new sources should be able to upload a python file which is used in argo workflow. 

Previously:
Argo workflow didn't had the context of the persistent/data_sources/retrieval/abc.py

Now:
We add a new volume and pass this as a volume mount to the argo workflow - which allows it to use the python script for a given source. 

