### PR TITLE
ESCKAN-103 - Enhance statement-validator.json schema by adding support for integer type for alert_type

### DIFF
--- a/applications/sckanner/backend/sckanner/services/ingestion/schemas/statement-validator.json
+++ b/applications/sckanner/backend/sckanner/services/ingestion/schemas/statement-validator.json
@@ -843,6 +843,9 @@
 									"type": "null"
 								},
 								{
+									"type": "integer"
+								},
+								{
 									"type": "string"
 								}
 							]

--- a/applications/sckanner/backend/sckanner/static/sckanner/schema/statement-validator.json
+++ b/applications/sckanner/backend/sckanner/static/sckanner/schema/statement-validator.json
@@ -843,6 +843,9 @@
 									"type": "null"
 								},
 								{
+									"type": "integer"
+								},
+								{
 									"type": "string"
 								}
 							]


### PR DESCRIPTION
Fix alert_type schema - extend to support integer as well as string.